### PR TITLE
✨Feat : 로그인 상태에 따른 main페이지 `내 맞춤 키워드`버튼 노출 처리

### DIFF
--- a/src/pages/mainpage/StickyTabSection.jsx
+++ b/src/pages/mainpage/StickyTabSection.jsx
@@ -1,51 +1,48 @@
-import { Box, Chip, IconButton, Stack, Tab } from "@mui/material";
-import { useEffect, useRef, useState } from "react";
-import { TabContext, TabList, TabPanel } from "@mui/lab";
-import { ChipStyle, MainStyles } from "../PageStyles";
-import arrowLeft from "../../../src/assets/icons/arrow-left.svg";
-import arrowRight from "../../../src/assets/icons/arrow-right.svg";
-import { useNavigate } from "react-router-dom";
-import { getHotSkills, getMemberSkills } from "../../api/api";
+import { Box, Chip, IconButton, Stack, Tab } from '@mui/material';
+import { useEffect, useRef, useState } from 'react';
+import { TabContext, TabList, TabPanel } from '@mui/lab';
+import { ChipStyle, MainStyles } from '../PageStyles';
+import arrowLeft from '../../../src/assets/icons/arrow-left.svg';
+import arrowRight from '../../../src/assets/icons/arrow-right.svg';
+import { useNavigate } from 'react-router-dom';
+import { getHotSkills, getMemberSkills } from '../../api/api';
+import { useRecoilValue } from 'recoil';
+import { isLoggedInState } from '../../recoil/atoms';
 
 function StickyTabSection({ selectedChip, setSelectedChip }) {
+  const isUserLoggedIn = useRecoilValue(isLoggedInState);
   const scrollRef = useRef(null);
   const navigate = useNavigate();
-  const [isLogin, setIsLogin] = useState(
-    localStorage.getItem("isLoggedInState")
-  );
-  const [value, setValue] = useState("1");
+  const [isLogin, setIsLogin] = useState(localStorage.getItem('isLoggedInState'));
+  const [value, setValue] = useState('1');
   const [hotSkills, setHotSkills] = useState([]);
   const [memberSkills, setMemberSkills] = useState([]);
 
   const handleConfirm = () => {
-    if (
-      window.confirm(
-        "[내 맞춤 키워드]는 로그인 후에 확인 하실 수 있습니다. 로그인페이지로 이동하시겠습니까?"
-      )
-    ) {
-      navigate("/signin");
+    if (window.confirm('[내 맞춤 키워드]는 로그인 후에 확인 하실 수 있습니다. 로그인페이지로 이동하시겠습니까?')) {
+      navigate('/signin');
     }
   };
 
   const GetMemberSkillData = async () => {
-    const storedIsLoggedIn = localStorage.getItem("isLoggedInState");
+    const storedIsLoggedIn = localStorage.getItem('isLoggedInState');
     setIsLogin(storedIsLoggedIn);
     console.log(storedIsLoggedIn);
-    if (storedIsLoggedIn === "true") {
+    if (storedIsLoggedIn === 'true') {
       try {
         const memData = await getMemberSkills();
         const memSkillsData = memData.data.skillList || { skillList: [] };
-        console.log("memSkillsData 확인중", memSkillsData);
+        console.log('memSkillsData 확인중', memSkillsData);
         setMemberSkills(memSkillsData);
       } catch (error) {
-        console.error("Error fetching member skills:", error);
+        console.error('Error fetching member skills:', error);
       }
     }
   };
 
   const handleTabChange = (e, newValue) => {
-    if (newValue === "2") {
-      if (isLogin === "false") {
+    if (newValue === '2') {
+      if (isLogin === 'false') {
         handleConfirm();
         return;
       } else {
@@ -55,7 +52,7 @@ function StickyTabSection({ selectedChip, setSelectedChip }) {
     setValue(newValue);
   };
   const handleSelectedChip = (keyword) => {
-    if (keyword === "") {
+    if (keyword === '') {
       setSelectedChip({
         keyword: keyword,
         userSelected: false,
@@ -71,15 +68,15 @@ function StickyTabSection({ selectedChip, setSelectedChip }) {
     const { current: scrollContainer } = scrollRef;
     if (scrollContainer) {
       const scrollAmount = scrollContainer.clientWidth;
-      if (direction === "left") {
+      if (direction === 'left') {
         scrollContainer.scrollTo({
           left: scrollContainer.scrollLeft - scrollAmount,
-          behavior: "smooth",
+          behavior: 'smooth',
         });
       } else {
         scrollContainer.scrollTo({
           left: scrollContainer.scrollLeft + scrollAmount,
-          behavior: "smooth",
+          behavior: 'smooth',
         });
       }
     }
@@ -91,7 +88,7 @@ function StickyTabSection({ selectedChip, setSelectedChip }) {
         const data = await getHotSkills();
         setHotSkills(data.data.skillList);
       } catch (error) {
-        console.error("Error fetching hot skills:", error);
+        console.error('Error fetching hot skills:', error);
       }
     };
     fetchHotSkills();
@@ -100,36 +97,24 @@ function StickyTabSection({ selectedChip, setSelectedChip }) {
     <>
       <Box
         sx={{
-          position: "sticky",
+          position: 'sticky',
           top: 0,
           left: 0,
           zIndex: 10,
-          bgcolor: "white",
+          bgcolor: 'white',
         }}
       >
         <TabContext value={value}>
-          <TabList
-            onChange={handleTabChange}
-            sx={{ pt: 2 }}
-            TabIndicatorProps={{ style: MainStyles.TabIndicator }}
-          >
+          <TabList onChange={handleTabChange} sx={{ pt: 2 }} TabIndicatorProps={{ style: MainStyles.TabIndicator }}>
             <Tab label="요즘 뜨는 키워드" value="1" sx={MainStyles.Tab} />
-            <Tab label="내 맞춤 키워드" value="2" sx={MainStyles.Tab} />
+            {isUserLoggedIn ? <Tab label="내 맞춤 키워드" value="2" sx={MainStyles.Tab} /> : ''}
           </TabList>
 
           <TabPanel value="1" sx={MainStyles.TabPanel}>
-            <IconButton
-              onClick={() => handleScroll("left")}
-              sx={MainStyles.IconButtonLeft}
-            >
+            <IconButton onClick={() => handleScroll('left')} sx={MainStyles.IconButtonLeft}>
               <img src={arrowLeft} alt="arrow" />
             </IconButton>
-            <Stack
-              direction="row"
-              spacing={0.8}
-              ref={scrollRef}
-              sx={MainStyles.ChipContainer}
-            >
+            <Stack direction="row" spacing={0.8} ref={scrollRef} sx={MainStyles.ChipContainer}>
               {hotSkills.map((skill) => (
                 <Chip
                   key={skill.id}
@@ -137,34 +122,24 @@ function StickyTabSection({ selectedChip, setSelectedChip }) {
                   label={skill.keyword}
                   clickable="true"
                   variant="outlined"
-                  sx={
-                    selectedChip.keyword === skill.keyword
-                      ? ChipStyle(selectedChip)
-                      : ChipStyle(undefined)
-                  }
+                  sx={selectedChip.keyword === skill.keyword ? ChipStyle(selectedChip) : ChipStyle(undefined)}
                 />
               ))}
             </Stack>
-            <IconButton
-              onClick={() => handleScroll("right")}
-              sx={MainStyles.IconButtonRight}
-            >
+            <IconButton onClick={() => handleScroll('right')} sx={MainStyles.IconButtonRight}>
               <img src={arrowRight} alt="arrow" />
             </IconButton>
           </TabPanel>
 
           <TabPanel value="2" sx={MainStyles.TabPanel}>
-            <IconButton
-              onClick={() => handleScroll("left")}
-              sx={MainStyles.IconButtonLeft}
-            >
+            <IconButton onClick={() => handleScroll('left')} sx={MainStyles.IconButtonLeft}>
               <img src={arrowLeft} alt="arrow" />
             </IconButton>
             <Stack
               direction="row"
               spacing={1}
               ref={scrollRef}
-              sx={{ ...MainStyles.ChipContainer, scrollBehavior: "smooth" }}
+              sx={{ ...MainStyles.ChipContainer, scrollBehavior: 'smooth' }}
             >
               {memberSkills.map((skill, index) => (
                 <Chip
@@ -173,18 +148,11 @@ function StickyTabSection({ selectedChip, setSelectedChip }) {
                   onClick={() => handleSelectedChip(skill.keyword)}
                   clickable="true"
                   variant="outlined"
-                  sx={
-                    selectedChip.keyword === skill.keyword
-                      ? ChipStyle(selectedChip)
-                      : ChipStyle(undefined)
-                  }
+                  sx={selectedChip.keyword === skill.keyword ? ChipStyle(selectedChip) : ChipStyle(undefined)}
                 />
               ))}
             </Stack>
-            <IconButton
-              onClick={() => handleScroll("right")}
-              sx={MainStyles.IconButtonRight}
-            >
+            <IconButton onClick={() => handleScroll('right')} sx={MainStyles.IconButtonRight}>
               <img src={arrowRight} alt="arrow" />
             </IconButton>
           </TabPanel>


### PR DESCRIPTION
## #️⃣연관된 이슈
close #169 

## 📝작업 내용
### 로그인 유무에 따라 버튼 노출을 처리했습니다.
![1](https://github.com/Kernel360/f1-JDON-Frontend/assets/122848687/98edf620-8311-4e80-9e92-f7c1f882b049)

`TabList` 부분만 감춰도 될 것 같아 현재는 아래와 같이 처리해둔 상태입니다!

```jsx
const isUserLoggedIn = useRecoilValue(isLoggedInState);
...
<TabList onChange={handleTabChange} sx={{ pt: 2 }} TabIndicatorProps={{ style: MainStyles.TabIndicator }}>
  <Tab label="요즘 뜨는 키워드" value="1" sx={MainStyles.Tab} />
  {isUserLoggedIn ? <Tab label="내 맞춤 키워드" value="2" sx={MainStyles.Tab} /> : ''}
</TabList>
...
```
