### PR TITLE
✨ Feat : 로그인 상태에 따른 마이페이지 접근 처리 #176

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,4 @@
-import { RecoilRoot } from "recoil";
+import { useRecoilValue } from "recoil";
 import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
 import "./App.css";
 import { Helmet } from "react-helmet";
@@ -17,19 +17,13 @@ import InfoEdit from "./pages/mypage/InfoEdit";
 import MyPage from "./pages/mypage/MyPage";
 import { Main } from "./pages/mainpage/Main";
 import Withdrawal from "./pages/mypage/Withdrawal";
-import React, { useState, useEffect } from "react";
+import React from "react";
 import RedirectPage from "./pages/sign-in/RedirectPage";
 import UpdateCoffeeForm from "./pages/coffee-detail/UpdateCoffeeForm";
+import { isLoggedInState } from "./recoil/atoms";
 
 function App() {
-  const [access, setAccess] = useState(
-    localStorage.getItem("isLoggedInState") === "true"
-  );
-
-  useEffect(() => {
-    const isLoggedIn = localStorage.getItem("isLoggedInState") === "true";
-    setAccess(isLoggedIn);
-  }, [access]);
+  const userLoggedIn = useRecoilValue(isLoggedInState);
 
   const privateRoutes = [
     { path: "/mypage", element: <MyPage /> },
@@ -55,12 +49,11 @@ function App() {
     return authenticated ? (
       children
     ) : (
-      <Navigate to="/" {...alert("접근할 수 없는 페이지입니다.")} />
+      <Navigate to="/signin" {...alert("로그인이 필요한 페이지입니다.")}/>
     );
   };
 
   return (
-    <RecoilRoot>
       <BrowserRouter>
         <ThemeProvider theme={theme}>
           <Layout>
@@ -71,7 +64,7 @@ function App() {
                     key={index}
                     path={route.path}
                     element={
-                      <PrivateRoute authenticated={access}>
+                      <PrivateRoute authenticated={userLoggedIn}>
                         {route.element}
                       </PrivateRoute>
                     }
@@ -97,7 +90,6 @@ function App() {
           </Layout>
         </ThemeProvider>
       </BrowserRouter>
-    </RecoilRoot>
   );
 }
 

--- a/src/components/common/card/VideoCard.jsx
+++ b/src/components/common/card/VideoCard.jsx
@@ -42,7 +42,7 @@ function VideoCard({ data, onSuccess, myFavorite, onError }) {
   };
   const promptLogin = () => {
     const confirmResult = window.confirm(
-      "[찜]은 로그인 후 이용할 수 있습니다. 로그인 페이지로 이동하시겠습니까?"
+      "찜하기는 로그인 후 이용할 수 있습니다. 로그인 하시겠습니까?"
     );
     if (confirmResult) {
       navigate("/signin");

--- a/src/index.js
+++ b/src/index.js
@@ -5,11 +5,14 @@ import reportWebVitals from "./reportWebVitals";
 
 import App from "./App.jsx";
 import HttpsRedirect from "react-https-redirect";
+import { RecoilRoot } from "recoil";
 
 const root = ReactDOM.createRoot(document.getElementById("root"));
 root.render(
   <HttpsRedirect>
-    <App />
+    <RecoilRoot>
+      <App />
+    </RecoilRoot>
   </HttpsRedirect>
 );
 reportWebVitals();

--- a/src/pages/mainpage/Main.jsx
+++ b/src/pages/mainpage/Main.jsx
@@ -1,5 +1,5 @@
 import { Container } from "@mui/material";
-import { useEffect, useRef } from "react";
+import { useRef } from "react";
 import BottomNav from "../../components/common/BottomNav";
 import CompanySection from "./CompanySection";
 import VideoSection from "./VideoSection";

--- a/src/pages/mainpage/StickyTabSection.jsx
+++ b/src/pages/mainpage/StickyTabSection.jsx
@@ -6,8 +6,6 @@ import arrowLeft from "../../../src/assets/icons/arrow-left.svg";
 import arrowRight from "../../../src/assets/icons/arrow-right.svg";
 import { useNavigate } from "react-router-dom";
 import { getHotSkills, getMemberSkills } from "../../api/api";
-import { useRecoilValue } from "recoil";
-import { isLoggedInState } from "../../recoil/atoms";
 
 function StickyTabSection({ selectedChip, setSelectedChip, isLogin }) {
   const scrollRef = useRef(null);

--- a/src/pages/sign-in/TitleLogo.jsx
+++ b/src/pages/sign-in/TitleLogo.jsx
@@ -1,7 +1,14 @@
 import { Divider, Typography } from "@mui/material";
 import logo from "../../assets/images/logo.svg";
+import { useNavigate } from "react-router-dom";
+import "./index.scss"
 
 function TitleLogo() {
+  const navigate = useNavigate()
+  
+  const logoClickHandler = () => {
+    navigate('/')
+  }
   return (
     <>
       <Typography
@@ -13,10 +20,10 @@ function TitleLogo() {
           textAlign: "center",
         }}
       >
-        {" "}
         당신의 job description을 on 할 시간
       </Typography>
-      <img src={logo} alt="logo" style={{ width: "45%" }} />
+      
+      <div class="loginLogo" onClick={logoClickHandler}><img src={logo} alt="logo" style={{ width: "45%" }} /></div>
       <Divider></Divider>
     </>
   );

--- a/src/pages/sign-in/index.scss
+++ b/src/pages/sign-in/index.scss
@@ -1,0 +1,3 @@
+.loginLogo{
+    cursor: pointer;
+}

--- a/src/recoil/atoms.jsx
+++ b/src/recoil/atoms.jsx
@@ -33,7 +33,3 @@ export const selectedJobSkillState = atom({
   default: [],
 });
 
-export const userLoginState = atom({
-  key: "userLoginState",
-  default: false,
-});


### PR DESCRIPTION
close #176 

## 📝작업 내용

## 1. 마이페이지 로그인 상태에 따른 접근처리 완료
이제 로그인을 하지 않은 상태에서 마이페이지와 그 하위 페이지를 접근하려고 하면,
alert 메세지를 띄운 뒤 강제로 로그인창으로 리다이렉트 시킵니다.

![image](https://github.com/Kernel360/f1-JDON-Frontend/assets/122848687/fcb28e9f-4428-4388-8a51-8dd13fa2d867)


<br/>
<br/>

## 2. 로그인 페이지 로고 핸들러 함수 추가
로그인 페이지에서 직접 뒤로가기를 누르는 것 이외에는 
홈화면으로 이동할 수 있는 수단이 없는 것 같아, 로고를 누르면 홈화면으로 이동할 수 있도록 핸들러 함수를 추가했습니다.

```jsx
const logoClickHandler = () => {
  navigate('/')
}
...
<div class="loginLogo" onClick={logoClickHandler}>
  <img src={logo} alt="logo" style={{ width: "45%" }} />
</div>
...
```

![1](https://github.com/Kernel360/f1-JDON-Frontend/assets/122848687/150d654c-d85d-42ef-9f65-0d6718211a3c)

<br/>
<br/>

### 그 이외에는 불필요한 코드정리 및 alert 멘트 수정 진행했습니다!


## 💬리뷰 요구사항(선택)
