### PR TITLE
🚨 Hotfix : 검색어 입력 시 api 무한호출되는 문제 수정

### DIFF
--- a/src/pages/coffee-detail/CoffeeDetailButtons.jsx
+++ b/src/pages/coffee-detail/CoffeeDetailButtons.jsx
@@ -15,19 +15,19 @@ function CoffeeDetailButtons({ id, host, coffeeChatData }) {
   const applyForCoffeeChat = async () => {
     try {
       await applyCoffeechat(id, applyCoffee);
-      if (
-        !window.confirm("신청이 완료되었습니다. 내 커피챗을 확인하시겠습니까?")
-      )
-        return;
-      navigate("/mypage");
+      const userConfirmed = window.confirm(
+        "신청이 완료되었습니다. 내 커피챗을 확인하시겠습니까?"
+      );
+      if (userConfirmed) {
+        navigate("/mypage");
+      }
     } catch (error) {
-      if (error.response?.status !== 409) {
-        console.log("신청 중 에러가 발생했습니다.");
+      const { status, message } = error.response.data;
+      if (status === 400 || status === 409) {
+        alert(message);
         return;
       }
-      alert("이미 신청된 커피챗입니다.");
       setIsApplied(true);
-      return;
     }
   };
 

--- a/src/pages/mainpage/HeaderWithSearchBar.jsx
+++ b/src/pages/mainpage/HeaderWithSearchBar.jsx
@@ -19,6 +19,7 @@ function HeaderWithSearchBar({ setSelectedChip }) {
     const newSearch = e.target.value;
     setSearch(newSearch);
   };
+
   return (
     <>
       <img

--- a/src/pages/mainpage/Main.jsx
+++ b/src/pages/mainpage/Main.jsx
@@ -11,7 +11,7 @@ import { useAuth } from "./useAuth";
 import { useLoadData } from "./useLoadData";
 
 export function Main() {
-  const isLogin = useAuth(); // 로그인 상태 관리
+  const isLogin = useAuth();
   const { selectedChip, setSelectedChip, lectureList, jdList } = useLoadData(); // 데이터 로딩 및 상태 관리
   const topRef = useRef(null);
 

--- a/src/pages/mainpage/useLoadData.jsx
+++ b/src/pages/mainpage/useLoadData.jsx
@@ -8,11 +8,11 @@ export function useLoadData() {
   const [isInitialLoad, setIsInitialLoad] = useState(true);
 
   const loadData = useCallback(
-    async (keyword, userSelected = false) => {
+    async (keyword, userSelected) => {
       const lectureData = await fetchLectureData(keyword);
       setLectureList(lectureData.lectureList);
       setJdList(lectureData.jdList);
-      if (isInitialLoad || userSelected) {
+      if (isInitialLoad) {
         setSelectedChip({ keyword: lectureData.keyword, userSelected });
         setIsInitialLoad(false);
       }
@@ -29,6 +29,7 @@ export function useLoadData() {
   useEffect(() => {
     if (selectedChip.userSelected) {
       loadData(selectedChip.keyword, true);
+      setIsInitialLoad(false);
     }
   }, [selectedChip, loadData]);
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> #183 

## 📝작업 내용

> 
### 1. api 무한호출 수정 
- 리팩토링과정에서 생긴 이슈였습니다,,

### 2. 커피챗 신청 에러 핸들링
기존:
- 409 에러 외의 에러는 핸들링하지 않음
```jsx
 catch (error) {
      if (error.response?.status !== 409) {
        ("신청 중 에러가 발생했습니다.");
        return;
        }
         alert("이미 신청된 커피챗입니다.");
```
변경 후:
- 에러 상태와 메세지를 저장해서 만약 에러번호 400 또는 409이면 alert 창을 통해 어떤 에러인지 메세지를 띄우도록 함
```jsx
 catch (error) {
      const { status, message } = error.response.data;
      if (status === 400 || status === 409) {
        alert(message);
        return;
      }
```

https://github.com/Kernel360/f1-JDON-Frontend/assets/103630185/6b8be29f-c4b2-48d0-a64b-9fc2f345c089



## 💬리뷰 요구사항(선택)
