### PR TITLE
🐛 Fix : JD 목록페이지 페이지네이션 및 검색관련 오류 수정

### DIFF
--- a/src/pages/jd-all/JDComponent.jsx
+++ b/src/pages/jd-all/JDComponent.jsx
@@ -3,12 +3,13 @@ import React, { useEffect, useState } from 'react';
 import CompanyCard from '../../components/common/card/CompanyCard';
 import { getAllJDByKeyword } from '../../api/api';
 import PaginationComponent from '../../components/common/Pagenation';
-import { useRecoilValue } from 'recoil';
+import { useRecoilValue, useResetRecoilState } from 'recoil';
 import { jdSearchValue } from '../../recoil/atoms';
 
 function JDComponent() {
   const searchValue = useRecoilValue(jdSearchValue);
-
+  const resetSearchValue = useResetRecoilState(jdSearchValue);
+  const [currentPage, setCurrentPage] = useState(1);
   const [jobData, setJobData] = useState({
     content: [],
     pageInfo: {
@@ -19,11 +20,15 @@ function JDComponent() {
       empty: true,
     },
   });
-  const [currentPage, setCurrentPage] = useState(1);
 
-  const handlePageChange = (_, newPage) => {
-    setCurrentPage(newPage);
-  };
+  useEffect(() => {
+    resetSearchValue(); // 페이지 재 진입시 검색 값 초기화
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    setCurrentPage(1); // 키워드 검색 시 페이지네이션 인덱스 초기화
+  }, [searchValue]);
 
   useEffect(() => {
     (async (currentPage) => {
@@ -35,6 +40,10 @@ function JDComponent() {
       }
     })(currentPage);
   }, [currentPage, jobData.pageInfo.pageSize, searchValue]);
+
+  const handlePageChange = (_, newPage) => {
+    setCurrentPage(newPage);
+  };
 
   return (
     <>

--- a/src/pages/jd-all/JDComponent.jsx
+++ b/src/pages/jd-all/JDComponent.jsx
@@ -22,7 +22,7 @@ function JDComponent() {
   });
 
   useEffect(() => {
-    resetSearchValue(); // 페이지 재 진입시 검색 값 초기화
+    resetSearchValue(); // 페이지 진입시 검색 값 초기화
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 


### PR DESCRIPTION
close #194 


# 오류 수정 완료했습니다!
![image](https://github.com/Kernel360/f1-JDON-Frontend/assets/122848687/0ed76de8-79e4-4f91-b930-0815c378aa5d)

![image](https://github.com/Kernel360/f1-JDON-Frontend/assets/122848687/010a75b5-c01c-45f8-802e-00446543fc66)


<br/>
<br/>

## 📝작업 내용

## 1. 페이지네이션 값 초기화 코드 추가
### 이제 다른 키워드를 검색하게 되면 페이지네이션이 `1페이지`로 되돌아갑니다.

| 이전상황 | 수정 후 |
|------|---|
| ![5](https://github.com/Kernel360/f1-JDON-Frontend/assets/122848687/815fe2f3-cab9-4354-a459-ca45e7c2ae42) | ![6](https://github.com/Kernel360/f1-JDON-Frontend/assets/122848687/e39d2cf1-ab30-49f2-929c-38cadc280a99) |
|이전 인덱스가 초기화되지 않아 `데이터 없음`이 뜸. | 이제 그런건 없습니다 ㅎ |

<br/>
<br/>


## 2. JD 목록 페이지 재 진입 시 이전값 조회 이슈
### 이전 검색 결과가 페이지 재 진입시에도 유지되던 문제를 해결했습니다.
![7](https://github.com/Kernel360/f1-JDON-Frontend/assets/122848687/b673da19-74a7-4690-9a60-9d79d5b66005)

<br/>
<br/>

## 💬 현재 발견한 이슈

### 1.  Authentication API 수정 필요 (memberId값 undefined 오류 발생)
- 이부분 [🐛 Fix: 수정된 커피챗 api 필드명 및 데이터 변경](https://github.com/Kernel360/f1-JDON-Frontend/pull/193) PR에도 남겨드린 내용이지만, 혹시나 해서 다시 노티드립니다.
<br/>

![image](https://github.com/Kernel360/f1-JDON-Frontend/assets/122848687/3eef9be9-c013-454f-9249-ff100d751a1a)
이쪽 부분의 api 호출이 잘못되어서 undefined 값이 나오는 것으로 보입니다.
```jsx
const res = await instance.get('/api/v1/authenticate');
    return res.data.data;
```
로 수정하셔야 할 것 같습니다.


