### PR TITLE
🐛 Fix: 02/29 수정 요청 사항

### DIFF
--- a/src/pages/PageStyles.js
+++ b/src/pages/PageStyles.js
@@ -36,8 +36,7 @@ export const signInTextFieldStyles = (value) => ({
   },
 });
 
-const TypoGraphyStyle =
-{
+const TypoGraphyStyle = {
   fontSize: "16px",
   fontWeight: 500,
   color: "black",
@@ -125,7 +124,7 @@ export const URLInput = () => ({
 export const BtnStyle = (value) => ({
   width: "100%",
   height: "55px",
-  background: value === "github" ? "black" : "#FEE500",
+  background: value === "github" ? "black" : "#FFD600",
   borderRadius: "10px",
   display: "flex",
   alignItems: "center",

--- a/src/pages/jd-detail/CategoryTab.jsx
+++ b/src/pages/jd-detail/CategoryTab.jsx
@@ -27,6 +27,8 @@ function TabPanelItem({ children, value }) {
 export function CategoryTab() {
   const [value, setValue] = useState("1");
   const [jdData, setJdData] = useState({});
+  const [reviewNum, setReviewNum] = useState(0);
+  const [isLoading, setIsLoading] = useState(true);
 
   const { id } = useParams();
 
@@ -36,8 +38,11 @@ export function CategoryTab() {
 
   useEffect(() => {
     (async () => {
+      setIsLoading(true); // 데이터 로딩 시작
       const res = await getJdDetail(id);
       setJdData(res);
+      setReviewNum(res.reviewCount);
+      setIsLoading(false); // 데이터 로딩 완료
     })();
   }, [id]);
 
@@ -51,9 +56,11 @@ export function CategoryTab() {
         >
           <Tab label="상세 정보" value="1" sx={MainStyles.Tab} />
           <Tab
-            label={`리뷰(${
-              jdData.reviewCount < 9 ? jdData.reviewCount : "9+"
-            })`}
+            label={
+              isLoading
+                ? "리뷰 로딩 중..."
+                : `리뷰(${reviewNum < 9 ? reviewNum : "9+"})`
+            }
             value="2"
             sx={MainStyles.Tab}
           />
@@ -62,7 +69,7 @@ export function CategoryTab() {
           <TabForInfo jdData={jdData} />
         </TabPanelItem>
         <TabPanelItem value="2">
-          <TabForReview id={id} />
+          <TabForReview id={id} setReviewNum={setReviewNum} />
         </TabPanelItem>
       </TabContext>
     </Box>

--- a/src/pages/jd-detail/CategoryTab.jsx
+++ b/src/pages/jd-detail/CategoryTab.jsx
@@ -39,7 +39,7 @@ export function CategoryTab() {
       const res = await getJdDetail(id);
       setJdData(res);
     })();
-  }, [id, jdData.reviewCount]);
+  }, [id]);
 
   return (
     <Box>

--- a/src/pages/jd-detail/TabForInfo.jsx
+++ b/src/pages/jd-detail/TabForInfo.jsx
@@ -7,8 +7,13 @@ function JdInfoForm({ title, mockData }) {
       <Typography color="#545459" fontSize="14px" fontWeight="700">
         {title}
       </Typography>
-      <Typography variant="body3" component="p" color="#9A9AA1" fontSize={14}>
-        {mockData}
+      <Typography variant="body3" component="div" color="#9A9AA1" fontSize={14}>
+        {mockData?.split("\n").map((line, index) => (
+          <p key={index}>
+            {line}
+            <br />
+          </p>
+        ))}
       </Typography>
     </Box>
   );

--- a/src/pages/jd-detail/TabForReview.jsx
+++ b/src/pages/jd-detail/TabForReview.jsx
@@ -9,7 +9,7 @@ import { isLoggedInState } from "../../recoil/atoms";
 import { ReviewPopup } from "./ReviewPopup";
 import { usePopup } from "../../components/common/usePopup";
 
-export function TabForReview({ id }) {
+export function TabForReview({ id, setReviewNum }) {
   const { isOpen, openPopup, closePopup } = usePopup();
   const loginState = useRecoilValue(isLoggedInState);
   const [reviewData, setReviewData] = useState({ content: [], pageInfo: {} });
@@ -50,6 +50,7 @@ export function TabForReview({ id }) {
     await addReivew({ jdId: Number(id), content: newReview.content });
     fetchReviewData(0);
     alert("리뷰가 등록되었습니다");
+    setReviewNum((prev) => prev + 1);
     closePopup();
   };
 
@@ -57,6 +58,7 @@ export function TabForReview({ id }) {
     await delReivew(reviewId);
     fetchReviewData(0);
     alert("리뷰가 정상적으로 삭제되었습니다");
+    setReviewNum((prev) => prev - 1);
   };
 
   return (

--- a/src/pages/sign-in/SignIn.jsx
+++ b/src/pages/sign-in/SignIn.jsx
@@ -17,13 +17,13 @@ export default function SignIn() {
           <TitleLogo />
           <Box sx={SignInStyle.BtnContainer}>
             <LoginBtn
-              title="카카오톡 로그인"
+              title="카카오톡으로 시작하기 "
               color="#191919"
               social="kakao"
               logo={kakao}
             />
             <LoginBtn
-              title="깃허브 로그인"
+              title="깃허브로 시작하기"
               color="white"
               social="github"
               logo={git}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #211 

## 📝작업 내용

> 
### 1. jd 상세 데이터의 줄바꿈 (₩n) 프론트에서 구분하기

>   "requirements": "[ 기본 자격 요건 ]\n\n\n** 신입의 경우 채용 대상이 아닙니다 **  \n\n  - 개발 경력을 보유하신 분\n  - HTML/CSS/Javascript를 능숙하게 사...

  
- 데이터가 응답바디에 이렇게 담겨오는데 기존에는 이 줄바꿈이 무시되고 프론트에 렌더링 되는 문제가 있었습니다
split 문법을 사용하여 `₩n`을 기준으로 `</ br>` 을 추가하도록 하였습니다

```jsx
 <Typography variant="body3" component="div" color="#9A9AA1" fontSize={14}>
    {mockData?.split("\n").map((line, index) => (
      <p key={index}>
        {line}
        <br />
      </p>
    ))}
</Typography>
```



### 2. 리뷰 탭 reviewCount 즉각렌더링 구현

- 기존 pr에서 작성했던 것과 같이 리뷰 개수가 리뷰 탭에서 보여지고 있는데 리뷰 추가/삭제 시 바뀐 리뷰 개수가 즉각적으로 재렌더링 되지 않는 문제가 있었습니다
state 변경이 될 때마다 재렌더링이 된다는 점을 고려하여 이렇게 reviewNum state을 추가하였고 삭제, 추가 될때마다 state을 변경해주었습니다!
`const [reviewNum, setReviewNum] = useState(0);`

- 바뀐 리뷰 데이터를 서버에서 받아오는 것이 아니라 프론트에서 처리를 하고 있지만 불필요한 api 방지를 위해 좋은 방법이 된 것 같습니다~👍


### 3. 로그인 버튼 워딩 수정

- 기존에는 "카카오톡 로그인", "깃허브 로그인" 이었지만  타서비스를 참고하여 시작하기로 바꾸었습니다
- 카카오톡 버튼 백그라운 색상도 조금 명도를 높혀 변경하였습니다~~

![Uploading image.png…]()


## 💬리뷰 요구사항(선택)
