### PR TITLE
♻️ Refactor : 종료된 커피챗 버튼 문구 변경 및 로딩 문구 자동변경 반영

### DIFF
--- a/src/pages/coffee-detail/CoffeeDetailButtons.jsx
+++ b/src/pages/coffee-detail/CoffeeDetailButtons.jsx
@@ -1,47 +1,41 @@
-import { Box, Button, Grid } from "@mui/material";
-import { buttonStyles } from "./ButtonStyle";
-import ShareIcon from "@mui/icons-material/Share";
-import NewBtn from "../../components/common/new-btn/NewBtn";
-import { theme } from "../../styles/themeMuiStyle";
-import { useNavigate } from "react-router-dom";
-import { applyCoffeechat, deleteCoffeechat } from "../../api/api";
-import { useEffect, useState } from "react";
+import { Box, Button, Grid } from '@mui/material';
+import { buttonStyles } from './ButtonStyle';
+import ShareIcon from '@mui/icons-material/Share';
+import NewBtn from 'components/common/new-btn/NewBtn';
+import { theme } from 'styles/themeMuiStyle';
+import { useNavigate } from 'react-router-dom';
+import { applyCoffeechat, deleteCoffeechat } from 'api/api';
+import { useEffect, useState } from 'react';
 
-function CoffeeDetailButtons({
-  id,
-  host,
-  coffeeChatData,
-  isParticipant,
-  setIsParticipant,
-}) {
+function CoffeeDetailButtons({ id, host, coffeeChatData, isParticipant, setIsParticipant }) {
   const navigate = useNavigate();
   const [applyCoffee, setApplyCoffee] = useState({});
-  const isButtonDisables = coffeeChatData.status !== "모집중" || isParticipant;
+  const isButtonDisables = coffeeChatData.status !== '모집중' || isParticipant;
 
   const applyButtonText = () => {
     switch (coffeeChatData.status) {
-      case "모집중":
-        return "신청하기";
-      case "모집종료":
-        return "모집 마감";
-      case "모집완료":
-        return "커피챗 종료";
+      case '모집중':
+        return '신청하기';
+      case '모집종료':
+        return '모집 마감';
+      case '모집완료':
+        return '종료된 커피챗입니다.';
       default:
-        return "상태 확인 중";
+        return '상태 확인 중';
     }
   };
 
   const applyForCoffeeChat = async () => {
     try {
       await applyCoffeechat(id, applyCoffee);
-      alert("신청이 완료되었습니다.");
+      alert('신청이 완료되었습니다.');
       setIsParticipant(true);
     } catch (error) {
       if (error.response?.status !== 409) {
-        console.log("신청 중 에러가 발생했습니다.");
+        console.log('신청 중 에러가 발생했습니다.');
         return;
       }
-      alert("이미 신청된 커피챗입니다.");
+      alert('이미 신청된 커피챗입니다.');
       return;
     }
   };
@@ -53,8 +47,8 @@ function CoffeeDetailButtons({
   const removeCoffeeChat = async () => {
     try {
       await deleteCoffeechat(id, applyCoffee);
-      alert("삭제가 완료되었습니다");
-      navigate("/coffee");
+      alert('삭제가 완료되었습니다.');
+      navigate('/coffee');
     } catch (error) {
       console.log(error);
     }
@@ -77,10 +71,10 @@ function CoffeeDetailButtons({
     navigator.clipboard
       .writeText(url)
       .then(() => {
-        alert("URL이 클립보드에 복사되었습니다.");
+        alert('URL이 클립보드에 복사되었습니다.');
       })
       .catch((err) => {
-        console.error("URL 복사에 실패했습니다.", err);
+        console.error('URL 복사에 실패했습니다.', err);
       });
   };
 
@@ -89,26 +83,20 @@ function CoffeeDetailButtons({
       <Box
         container
         sx={{
-          width: "100%",
-          display: "flex",
-          justifyContent: "space-between",
-          gap: "20px",
+          width: '100%',
+          display: 'flex',
+          justifyContent: 'space-between',
+          gap: '20px',
         }}
       >
-        <Grid
-          item
-          xs={8}
-          sm={8}
-          fullwidth
-          sx={{ display: "flex", gap: "12px", flexGrow: 1 }}
-        >
+        <Grid item xs={8} sm={8} fullwidth sx={{ display: 'flex', gap: '12px', flexGrow: 1 }}>
           {host ? (
             <>
               <NewBtn
                 title="수정하기"
                 styles={{
                   background: theme.palette.primary.main,
-                  color: "white",
+                  color: 'white',
                 }}
                 onClick={editCoffeeChat}
               />
@@ -116,19 +104,17 @@ function CoffeeDetailButtons({
                 title="삭제하기"
                 styles={{
                   background: theme.palette.primary.main,
-                  color: "white",
+                  color: 'white',
                 }}
                 onClick={removeCoffeeChat}
               />
             </>
           ) : (
             <NewBtn
-              title={isParticipant ? "신청완료" : applyButtonText()}
+              title={isParticipant ? '신청완료' : applyButtonText()}
               styles={{
-                background: isButtonDisables
-                  ? "#EBEBEB"
-                  : theme.palette.primary.main,
-                color: "white",
+                background: isButtonDisables ? '#EBEBEB' : theme.palette.primary.main,
+                color: 'white',
               }}
               onClick={applyForCoffeeChat}
               disable={isButtonDisables}

--- a/src/pages/coffeechat/Coffee.jsx
+++ b/src/pages/coffeechat/Coffee.jsx
@@ -28,6 +28,19 @@ export function Coffee() {
   const [currentPage, setCurrentPage] = useState(1);
   const [kindOfJd, setKindOfJd] = useRecoilState(kindOfJdState);
 
+  // 추후 스켈레톤 UI 반영 시 지울 내용입니다.
+  const [foundTxt, setFoundTxt] = useState('커피챗 정보 불러오는 중..');
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setFoundTxt('커피챗 정보가 없습니다.');
+    }, 1500);
+    return () => {
+      clearTimeout(timer);
+    };
+  }, []);
+  // --------------------------------
+
   const handlePageChange = (_, newPage) => {
     setCurrentPage(newPage);
   };
@@ -83,7 +96,7 @@ export function Coffee() {
               fontWeight: 600,
             }}
           >
-            커피챗 정보가 없습니다.
+            {foundTxt}
           </Typography>
         )}
       </Grid>

--- a/src/pages/jd-all/JDComponent.jsx
+++ b/src/pages/jd-all/JDComponent.jsx
@@ -21,6 +21,19 @@ function JDComponent() {
     },
   });
 
+  // 추후 스켈레톤 UI 반영 시 지울 내용입니다.
+  const [foundTxt, setFoundTxt] = useState('회사 정보 불러오는 중..');
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setFoundTxt('관련된 회사 정보가 존재하지 않습니다.');
+    }, 1500);
+    return () => {
+      clearTimeout(timer);
+    };
+  }, []);
+  // --------------------------------
+
   useEffect(() => {
     resetSearchValue(); // 페이지 진입시 검색 값 초기화
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -74,7 +87,7 @@ function JDComponent() {
                 textAlign: 'center',
               }}
             >
-              회사 데이터가 존재하지 않습니다
+              {foundTxt}
             </div>
           </Box>
         )}

--- a/src/pages/mainpage/CompanySection.jsx
+++ b/src/pages/mainpage/CompanySection.jsx
@@ -1,8 +1,21 @@
 import { Box, Grid, Typography } from '@mui/material';
 import CompanyCard from '../../components/common/card/CompanyCard';
 import { MainStyles } from '../PageStyles';
+import { useEffect, useState } from 'react';
 
 function CompanySection({ selectedChip, data }) {
+  // 추후 스켈레톤 UI 반영 시 지울 내용입니다.
+  const [foundTxt, setFoundTxt] = useState('회사 정보 불러오는 중..');
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setFoundTxt('관련된 회사 정보가 존재하지 않습니다.');
+    }, 1500);
+    return () => {
+      clearTimeout(timer);
+    };
+  }, []);
+  // --------------------------------
   return (
     <Box sx={{ mt: 8 }}>
       <Typography sx={MainStyles.JDTypoGraphy}>
@@ -48,7 +61,7 @@ function CompanySection({ selectedChip, data }) {
                 textAlign: 'center',
               }}
             >
-              회사 데이터가 존재하지 않습니다
+              {foundTxt}
             </div>
           </Box>
         )}

--- a/src/pages/mypage/FavoritesVideo.jsx
+++ b/src/pages/mypage/FavoritesVideo.jsx
@@ -1,16 +1,29 @@
-import React, { useState, useEffect } from "react";
-import { Container, Box, Typography, Grid } from "@mui/material";
-import BottomNav from "../../components/common/BottomNav";
-import VideoCard from "../../components/common/card/VideoCard";
-import { getFavoritVideo } from "../../api/api";
-import Header from "../../components/common/Header";
-import Pagenation from "../../components/common/Pagenation";
+import React, { useState, useEffect } from 'react';
+import { Container, Box, Typography, Grid } from '@mui/material';
+import BottomNav from '../../components/common/BottomNav';
+import VideoCard from '../../components/common/card/VideoCard';
+import { getFavoritVideo } from '../../api/api';
+import Header from '../../components/common/Header';
+import Pagenation from '../../components/common/Pagenation';
 
 export default function FavoritesVideo() {
   const [datas, setDatas] = useState(null);
   const [currentPage, setCurrentPage] = useState(1);
   const [page, setPage] = useState({});
   const [isFavoriteChanged, setIsFavoriteChanged] = useState(false);
+
+  // 추후 스켈레톤 UI 반영 시 지울 내용입니다.
+  const [foundTxt, setFoundTxt] = useState('찜한 영상 불러오는 중..');
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setFoundTxt('찜한 영상이 없습니다.');
+    }, 1500);
+    return () => {
+      clearTimeout(timer);
+    };
+  }, []);
+  // --------------------------------
 
   useEffect(() => {
     const fetchData = async () => {
@@ -21,7 +34,7 @@ export default function FavoritesVideo() {
         // console.log("찜 확인11", res);
         // console.log("datas", datas);
       } catch (error) {
-        console.error("getFavoritVideo API 에러", error);
+        console.error('getFavoritVideo API 에러', error);
       }
     };
     // 최초 렌더링 시에만 fetchData 호출
@@ -40,14 +53,14 @@ export default function FavoritesVideo() {
     <Container
       maxWidth="md"
       sx={{
-        display: "flex",
-        flexDirection: "column",
-        minHeight: "95vh",
-        minwidth: "100vw",
+        display: 'flex',
+        flexDirection: 'column',
+        minHeight: '95vh',
+        minwidth: '100vw',
         pb: 10,
       }}
     >
-      <Header title={"찜"} />
+      <Header title={'찜'} />
       <Grid container spacing={{ xs: 2, md: 2 }} sx={{ px: 2, py: 1 }}>
         {datas && datas.length > 0 ? (
           datas.map((item, index) => (
@@ -56,28 +69,24 @@ export default function FavoritesVideo() {
             </Grid>
           ))
         ) : (
-          <Box mt={9} sx={{ width: "100%" }}>
+          <Box mt={9} sx={{ width: '100%' }}>
             <Typography
               variant="h6"
               color="textSecondary"
               sx={{
-                textAlign: "center",
+                textAlign: 'center',
                 fontSize: 16,
                 mt: 3,
               }}
             >
-              찜한 영상이 없습니다!
+              {foundTxt}
             </Typography>
           </Box>
         )}
       </Grid>
       {datas && (
         <Box mt={4}>
-          <Pagenation
-            pageCount={page?.totalPages}
-            currentPage={currentPage}
-            onChange={handlePageChange}
-          />
+          <Pagenation pageCount={page?.totalPages} currentPage={currentPage} onChange={handlePageChange} />
         </Box>
       )}
       <BottomNav></BottomNav>


### PR DESCRIPTION
## #️⃣연관된 이슈

-

## 📝작업 내용

## 1. 커피챗 버튼문구 수정 완료
> 종료된 커피챗의 문구를 수정하여 반영하였습니다.
화면을 사진으로 보여드리고 싶은데, 
아직 지원님께서 달력부분 작업중이셔서 준비된 화면이 없습니다 ㅠㅠ

![image](https://github.com/Kernel360/f1-JDON-Frontend/assets/122848687/b7a4845e-eae8-4572-8461-ac64817ddfa3)

대신 반영한 코드라도 보여드리겠습니다...ㅎ

<br/><br/>

## 2. 페이지별 로딩 문구 수정 완료
스켈레톤 UI 반영 전까지는 아무래도 로딩 문구가 `데이터가 없습니다`로 Fixed 되어있으면
사용자 입장에서 일시적인 오류라고 판단할 수 있는 여지가 있어, 
`1.5초` 이후에 문구가 자동으로 변경될 수 있도록 코드를 구성했습니다.

![15](https://github.com/Kernel360/f1-JDON-Frontend/assets/122848687/fb2b457e-f6e9-4ac4-8e54-48e44506afc6)

<br/>

### JD 페이지같이 약속된 데이터가 오는 페이지의 경우 이렇게 보일 예정입니다.
![16](https://github.com/Kernel360/f1-JDON-Frontend/assets/122848687/9a28ff38-4dbe-4abc-a4ea-e2c0adb01333)

