### PR TITLE
🐛 Fix: 인풋 유효성 검사 추가

### DIFF
--- a/src/api/api.js
+++ b/src/api/api.js
@@ -14,6 +14,7 @@ instance.interceptors.response.use(
   },
   (error) => {
     if (error.response && error.response.status === 401) {
+      alert("로그인이 필요한 서비스입니다");
       window.location.href = "/signin";
     }
     return Promise.reject(error);

--- a/src/components/common/BottomNav.jsx
+++ b/src/components/common/BottomNav.jsx
@@ -1,34 +1,36 @@
-import React, { useState, useEffect } from 'react';
-import { useNavigate, useLocation } from 'react-router-dom';
-import BottomNavigation from '@mui/material/BottomNavigation';
-import BottomNavigationAction from '@mui/material/BottomNavigationAction';
-import { Box } from '@mui/material';
-import HomeIcon from '@mui/icons-material/CottageTwoTone';
-import WorkIcon from '@mui/icons-material/Work';
-import CoffeeIcon from '@mui/icons-material/EmojiFoodBeverageTwoTone';
-import PersonIcon from '@mui/icons-material/AccountCircleTwoTone';
+import React, { useState, useEffect } from "react";
+import { useNavigate, useLocation } from "react-router-dom";
+import BottomNavigation from "@mui/material/BottomNavigation";
+import BottomNavigationAction from "@mui/material/BottomNavigationAction";
+import { Box } from "@mui/material";
+import HomeIcon from "@mui/icons-material/CottageTwoTone";
+import WorkIcon from "@mui/icons-material/Work";
+import CoffeeIcon from "@mui/icons-material/EmojiFoodBeverageTwoTone";
+import PersonIcon from "@mui/icons-material/AccountCircleTwoTone";
+import { useRecoilValue } from "recoil";
+import { isLoggedInState } from "recoil/atoms";
 
 export default function BottomNav() {
   const navigate = useNavigate();
   const location = useLocation();
   const [value, setValue] = useState(0);
-  const isLogin = localStorage.getItem('isLoggedInState');
+  const userLogin = useRecoilValue(isLoggedInState).loginUser;
 
   useEffect(() => {
     switch (true) {
-      case location.pathname === '/':
+      case location.pathname === "/":
         setValue(0);
         break;
-      case location.pathname === '/jd':
+      case location.pathname === "/jd":
         setValue(1);
         break;
-      case location.pathname === '/coffee':
+      case location.pathname === "/coffee":
         setValue(2);
         break;
-      case location.pathname === '/signin':
+      case location.pathname === "/signin":
         setValue(3);
         break;
-      case location.pathname.startsWith('/mypage'):
+      case location.pathname.startsWith("/mypage"):
         setValue(3);
         break;
       default:
@@ -40,16 +42,16 @@ export default function BottomNav() {
     setValue(newValue);
     switch (newValue) {
       case 0:
-        navigate('/');
+        navigate("/");
         break;
       case 1:
-        navigate('/jd');
+        navigate("/jd");
         break;
       case 2:
-        navigate('/coffee');
+        navigate("/coffee");
         break;
       case 3:
-        navigate(isLogin === 'true' ? '/mypage' : '/signin');
+        navigate(userLogin ? "/mypage" : "/signin");
         break;
       default:
         break;
@@ -57,23 +59,32 @@ export default function BottomNav() {
   };
 
   return (
-    <Box sx={{ position: 'fixed', bottom: 0, left: 0, right: 0 }}>
+    <Box sx={{ position: "fixed", bottom: 0, left: 0, right: 0 }}>
       <BottomNavigation
         value={value}
         onChange={handleNavigationChange}
         showLabels
         sx={{
           height: 80,
-          display: 'flex',
-          gap: { xs: 'inherit', sm: '8%' },
-          borderTop: '1px solid light-gray',
+          display: "flex",
+          gap: { xs: "inherit", sm: "8%" },
+          borderTop: "1px solid light-gray",
         }}
       >
-        <BottomNavigationAction label="메인" icon={<HomeIcon fontSize="medium" />} />
-        <BottomNavigationAction label="JD-ON" icon={<WorkIcon fontSize="medium" />} />
-        <BottomNavigationAction label="커피챗" icon={<CoffeeIcon fontSize="medium" />} />
         <BottomNavigationAction
-          label={isLogin === 'true' ? 'My page' : '로그인'}
+          label="메인"
+          icon={<HomeIcon fontSize="medium" />}
+        />
+        <BottomNavigationAction
+          label="JD-ON"
+          icon={<WorkIcon fontSize="medium" />}
+        />
+        <BottomNavigationAction
+          label="커피챗"
+          icon={<CoffeeIcon fontSize="medium" />}
+        />
+        <BottomNavigationAction
+          label={userLogin ? "My page" : "로그인"}
           icon={<PersonIcon fontSize="medium" />}
         />
       </BottomNavigation>

--- a/src/components/common/new-daypicker/NewDayPicker.jsx
+++ b/src/components/common/new-daypicker/NewDayPicker.jsx
@@ -33,7 +33,6 @@ function InputComponent({ value, onChange, children, disablePast, maxDate }) {
 }
 
 function NewDayPicker({ label, value, onChange, valid, helperText, daytime }) {
-  console.log(value);
   const now = new Date();
   const handleDateChange = (newDate) => {
     if (typeof newDate === "string") {

--- a/src/pages/coffeechat/CoffeeOpen.jsx
+++ b/src/pages/coffeechat/CoffeeOpen.jsx
@@ -91,7 +91,7 @@ function Coffeeopen() {
         return;
       }
       setIsRegistered(true);
-      alert("신청이 완료되었습니다");
+      alert("등록이 완료되었습니다");
       navigate(`/coffee/${res.data}`);
     } catch (error) {
       console.error("Error registering coffee chat:", error);

--- a/src/pages/coffeechat/CoffeeOpen.jsx
+++ b/src/pages/coffeechat/CoffeeOpen.jsx
@@ -1,12 +1,12 @@
 import { Box, Container, CssBaseline, Grid, Typography } from "@mui/material";
-import Header from "../../components/common/Header";
-import NewInput from "../../components/common/new-input/NewInput";
-import NewDayPicker from "../../components/common/new-daypicker/NewDayPicker";
+import Header from "components/common/Header";
+import NewInput from "components/common/new-input/NewInput";
+import NewDayPicker from "components/common/new-daypicker/NewDayPicker";
 import { useEffect, useState } from "react";
-import { registerCoffeeChat } from "../../api/api";
+import { registerCoffeeChat } from "api/api";
 import { useNavigate } from "react-router-dom";
-import { theme } from "../../styles/themeMuiStyle";
-import NewBtn from "../../components/common/new-btn/NewBtn";
+import { theme } from "styles/themeMuiStyle";
+import NewBtn from "components/common/new-btn/NewBtn";
 
 function Coffeeopen() {
   const navigate = useNavigate();

--- a/src/pages/coffeechat/CoffeeOpen.jsx
+++ b/src/pages/coffeechat/CoffeeOpen.jsx
@@ -43,8 +43,8 @@ function Coffeeopen() {
             : "";
         break;
       case "totalRecruitCount":
-        helperText = value > 500 ? "500명 이하로 입력해주세요" : "";
-
+        helperText =
+          !isNaN(value) && value > 500 ? "500명 이하로 입력해주세요" : "";
         break;
       case "openChatUrl":
         helperText =
@@ -89,9 +89,8 @@ function Coffeeopen() {
         return;
       }
       setIsRegistered(true);
-      window.confirm(
-        "신청이 완료되었습니다. 커피챗 신청 내역을 확인하시겠습니까?"
-      ) && navigate(`/coffee/${res.data}`);
+      alert("신청이 완료되었습니다");
+      navigate(`/coffee/${res.data}`);
     } catch (error) {
       console.error("Error registering coffee chat:", error);
     }

--- a/src/pages/coffeechat/CoffeeOpen.jsx
+++ b/src/pages/coffeechat/CoffeeOpen.jsx
@@ -33,22 +33,24 @@ function Coffeeopen() {
       case "title":
         helperText =
           value.length < 10 || value.length > 50
-            ? "10자 이상 50자 이하로 입력해주세요"
+            ? "제목은 10자 이상 50자 이하로 작성해주세요"
             : "";
         break;
       case "content":
         helperText =
           value.length < 50 || value.length > 500
-            ? "50자 이상 500자 이하로 입력해주세요"
+            ? "내용은 50자 이상 500자 이하로 작성해주세요"
             : "";
         break;
       case "totalRecruitCount":
         helperText =
-          !isNaN(value) && value > 500 ? "500명 이하로 입력해주세요" : "";
+          !isNaN(value) && value > 100
+            ? "모집인원은 1명 이상 100명 이하로 설정해주세요"
+            : "";
         break;
       case "openChatUrl":
         helperText =
-          value && !isValidUrl(value) ? "올바른 URL 형식을 입력해주세요" : "";
+          value && !isValidUrl(value) ? "URL형식이 올바르지 않습니다" : "";
         break;
       default:
         return;

--- a/src/pages/coffeechat/CoffeeOpen.jsx
+++ b/src/pages/coffeechat/CoffeeOpen.jsx
@@ -1,15 +1,8 @@
-import {
-  Box,
-  Button,
-  Container,
-  CssBaseline,
-  Grid,
-  Typography,
-} from "@mui/material";
+import { Box, Container, CssBaseline, Grid, Typography } from "@mui/material";
 import Header from "../../components/common/Header";
 import NewInput from "../../components/common/new-input/NewInput";
 import NewDayPicker from "../../components/common/new-daypicker/NewDayPicker";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { registerCoffeeChat } from "../../api/api";
 import { useNavigate } from "react-router-dom";
 import { theme } from "../../styles/themeMuiStyle";
@@ -26,11 +19,62 @@ function Coffeeopen() {
   });
 
   const [isRegistered, setIsRegistered] = useState(false);
-  const [helperText, setHelperText] = useState("");
+  const [helperTexts, setHelperTexts] = useState({});
+  const [isFormValid, setIsFormValid] = useState(false);
 
   const updateFormValue = (field, newValue) => {
     setFormValue((prev) => ({ ...prev, [field]: newValue }));
+    validateField(field, newValue);
   };
+
+  const validateField = (field, value) => {
+    let helperText = "";
+    switch (field) {
+      case "title":
+        helperText =
+          value.length < 10 || value.length > 50
+            ? "10자 이상 50자 이하로 입력해주세요"
+            : "";
+        break;
+      case "content":
+        helperText =
+          value.length < 50 || value.length > 500
+            ? "50자 이상 500자 이하로 입력해주세요"
+            : "";
+        break;
+      case "totalRecruitCount":
+        helperText = value > 500 ? "500명 이하로 입력해주세요" : "";
+
+        break;
+      case "openChatUrl":
+        helperText =
+          value && !isValidUrl(value) ? "올바른 URL 형식을 입력해주세요" : "";
+        break;
+      default:
+        return;
+    }
+    setHelperTexts((prev) => ({ ...prev, [field]: helperText }));
+  };
+
+  const isValidUrl = (url) => {
+    const pattern = new RegExp(
+      "^(https?:\\/\\/)?" + // protocol
+        "((([a-z\\d]([a-z\\d-]*[a-z\\d])*)\\.)+[a-z]{2,}|" + // domain name
+        "((\\d{1,3}\\.){3}\\d{1,3}))" + // OR ip (v4) address
+        "(\\:\\d+)?(\\/[-a-z\\d%_.~+]*)*" + // port and path
+        "(\\?[;&a-z\\d%_.~+=-]*)?" + // query string
+        "(\\#[-a-z\\d_]*)?$",
+      "i"
+    );
+    return pattern.test(url);
+  };
+
+  useEffect(() => {
+    const isValid =
+      Object.values(helperTexts).every((text) => text === "") &&
+      Object.values(formValue).every((value) => value);
+    setIsFormValid(isValid);
+  }, [formValue, helperTexts]);
 
   const submitCoffeeChat = async (e) => {
     e.preventDefault();
@@ -55,22 +99,13 @@ function Coffeeopen() {
 
   const formatDateTime = (date) => {
     if (!date) return;
-
     const time = date.getHours() + ":" + date.getMinutes();
-
     const isoDate = date.toISOString();
-
     const [datePart] = isoDate.split("T");
-
     const [year, month, day] = datePart.split("-");
     const formattedDate = `${year}-${month}-${day} ${time}`;
-
     updateFormValue("meetDate", formattedDate);
-
-    console.log("변환한 데이터", formattedDate);
   };
-
-  const allFieldsFilled = Object.values(formValue).every((value) => value);
 
   return (
     <Container maxWidth="sm" display="flex" flexDirection="column">
@@ -102,20 +137,17 @@ function Coffeeopen() {
           <NewInput
             placeholder="커피챗 제목을 입력해주세요"
             label="제목"
+            helperText={helperTexts.title}
             value={formValue.title}
-            valid={false}
-            onChange={(e) => {
-              updateFormValue("title", e.target.value);
-            }}
+            onChange={(e) => updateFormValue("title", e.target.value)}
           />
           <NewInput
             placeholder="커피챗 내용을 입력해주세요"
             label="상세 내용"
+            helperText={helperTexts.content}
             value={formValue.content}
             isMultiline={true}
-            onChange={(e) => {
-              updateFormValue("content", e.target.value);
-            }}
+            onChange={(e) => updateFormValue("content", e.target.value)}
           />
           <Box>
             <Grid
@@ -128,20 +160,22 @@ function Coffeeopen() {
                 <NewInput
                   placeholder="숫자만 입력해주세요"
                   label="총 모집 인원"
-                  helperText={helperText}
+                  helperText={helperTexts.totalRecruitCount}
                   type="number"
                   min={0}
-                  value={
-                    formValue.totalRecruitCount && formValue.totalRecruitCount
-                  }
+                  value={formValue.totalRecruitCount}
                   onChange={(e) => {
-                    const newValue = e.target.value;
-                    if (!isNaN(newValue) && parseInt(newValue, 10) >= 0) {
-                      updateFormValue(
-                        "totalRecruitCount",
-                        parseInt(newValue, 10)
-                      );
-                    }
+                    updateFormValue(
+                      "totalRecruitCount",
+                      parseInt(e.target.value, 10)
+                    );
+                    // const newValue = e.target.value;
+                    // if (!isNaN(newValue) && parseInt(newValue, 10) >= 0) {
+                    //   updateFormValue(
+                    //     "totalRecruitCount",
+                    //     parseInt(newValue, 10)
+                    //   );
+                    // }
                   }}
                 />
               </Grid>
@@ -151,9 +185,7 @@ function Coffeeopen() {
                   label="일시"
                   daytime={true}
                   value={formValue.meetDate}
-                  onChange={(newValue) => {
-                    formatDateTime(newValue);
-                  }}
+                  onChange={(newValue) => formatDateTime(newValue)}
                 />
               </Grid>
             </Grid>
@@ -161,26 +193,25 @@ function Coffeeopen() {
           <NewInput
             placeholder="오픈채팅방 링크를 입력해주세요"
             label="오픈채팅방 링크"
+            helperText={helperTexts.openChatUrl}
             value={formValue.openChatUrl}
-            onChange={(e) => {
-              updateFormValue("openChatUrl", e.target.value);
-            }}
+            onChange={(e) => updateFormValue("openChatUrl", e.target.value)}
           />
           <NewBtn
             title={isRegistered ? "이미 등록된 커피챗입니다" : "등록하기"}
             onClick={submitCoffeeChat}
-            disable={!allFieldsFilled || isRegistered}
-            isActive={!allFieldsFilled || isRegistered}
+            disable={!isFormValid || isRegistered}
+            isActive={!isFormValid || isRegistered}
             styles={{
               width: "100%",
               p: "13px",
               fontSize: "16px",
               borderRadius: "999px",
               background:
-                !isRegistered && allFieldsFilled
+                !isRegistered && isFormValid
                   ? theme.palette.primary.main
                   : "#EBEBEB",
-              color: !isRegistered && allFieldsFilled ? "white" : "#BCBCC4",
+              color: !isRegistered && isFormValid ? "white" : "#BCBCC4",
             }}
           />
         </Box>

--- a/src/pages/info/InFoBasic.jsx
+++ b/src/pages/info/InFoBasic.jsx
@@ -36,7 +36,6 @@ function InFoBasic({ agree, setAgree }) {
 
   const handleInputChange = async (field, newValue) => {
     setValue((prev) => ({ ...prev, [field]: newValue }));
-    console.log(value);
   };
 
   const handleAgreeChange = (event) => {

--- a/src/pages/jd-detail/CategoryTab.jsx
+++ b/src/pages/jd-detail/CategoryTab.jsx
@@ -6,6 +6,8 @@ import { TabForReview } from "./TabForReview";
 import { MainStyles } from "../PageStyles";
 import { getJdDetail } from "../../api/api";
 import { useParams } from "react-router-dom";
+import { useRecoilValue } from "recoil";
+import { isLoggedInState } from "recoil/atoms";
 
 function TabPanelItem({ children, value }) {
   return (
@@ -38,11 +40,11 @@ export function CategoryTab() {
 
   useEffect(() => {
     (async () => {
-      setIsLoading(true); // 데이터 로딩 시작
+      setIsLoading(true);
       const res = await getJdDetail(id);
       setJdData(res);
       setReviewNum(res.reviewCount);
-      setIsLoading(false); // 데이터 로딩 완료
+      setIsLoading(false);
     })();
   }, [id]);
 

--- a/src/pages/jd-detail/ReviewPopup.jsx
+++ b/src/pages/jd-detail/ReviewPopup.jsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { BackDrop } from "../../components/common/BackDrop";
 import NewInput from "../../components/common/new-input/NewInput";
 import { Box } from "@mui/material";
@@ -7,6 +7,8 @@ import { PopupFrame } from "../../components/common/PopupFrame";
 
 export function ReviewPopup({ isOpen, closePopup, addReviewAndUpdate }) {
   const [reviewInput, setReviewInput] = useState();
+  const [helperText, setHelperText] = useState("");
+  const [isValid, setIsValid] = useState(false);
 
   const handleClose = (e) => {
     if (e.target === e.currentTarget) {
@@ -15,11 +17,23 @@ export function ReviewPopup({ isOpen, closePopup, addReviewAndUpdate }) {
   };
 
   const handleAddReview = async () => {
+    if (!isValid) return;
     const newReview = {
       content: reviewInput,
     };
     await addReviewAndUpdate(newReview);
     setReviewInput("");
+  };
+
+  const checkValidation = (value) => {
+    if (value.length < 10 || value.length > 500) {
+      setHelperText("10자 이상 500자 이하로 입력해주세요");
+      setIsValid(false);
+    } else {
+      setHelperText("");
+      setIsValid(true);
+    }
+    setReviewInput(value);
   };
 
   return (
@@ -28,17 +42,18 @@ export function ReviewPopup({ isOpen, closePopup, addReviewAndUpdate }) {
         <Box sx={{ width: "90%", margin: "0 auto", py: 5 }}>
           <NewInput
             type="text"
+            helperText={helperText}
             isMultiline={true}
             value={reviewInput}
             placeholder="리뷰를 입력해주세요"
             label="리뷰를 남겨주세요!"
-            onChange={(e) => setReviewInput(e.target.value)}
+            onChange={(e) => checkValidation(e.target.value)}
           />
           <NewBtn
             title="등록하기"
-            disable={!reviewInput}
+            disable={!isValid}
             onClick={handleAddReview}
-            isActive={reviewInput}
+            isActive={isValid}
           />
         </Box>
       </PopupFrame>

--- a/src/pages/jd-detail/ReviewPopup.jsx
+++ b/src/pages/jd-detail/ReviewPopup.jsx
@@ -27,7 +27,7 @@ export function ReviewPopup({ isOpen, closePopup, addReviewAndUpdate }) {
 
   const checkValidation = (value) => {
     if (value.length < 10 || value.length > 500) {
-      setHelperText("10자 이상 500자 이하로 입력해주세요");
+      setHelperText("내용은 10자 이상 500자 이하로 작성해주세요");
       setIsValid(false);
     } else {
       setHelperText("");

--- a/src/pages/jd-detail/addReviewButton.jsx
+++ b/src/pages/jd-detail/addReviewButton.jsx
@@ -1,8 +1,8 @@
 import { Box } from "@mui/material";
-import { theme } from "../../styles/themeMuiStyle";
-import add from "../../assets/icons/review_add.svg";
+import { theme } from "styles/themeMuiStyle";
+import add from "assets/icons/review_add.svg";
 import { useRecoilValue } from "recoil";
-import { isLoggedInState } from "../../recoil/atoms";
+import { isLoggedInState } from "recoil/atoms";
 
 export const AddReviewButton = ({ openPopup }) => {
   const loginState = useRecoilValue(isLoggedInState);

--- a/src/pages/sign-in/SignIn.jsx
+++ b/src/pages/sign-in/SignIn.jsx
@@ -1,12 +1,12 @@
-import React from 'react';
-import CssBaseline from '@mui/material/CssBaseline';
-import Box from '@mui/material/Box';
-import Container from '@mui/material/Container';
-import { SignInStyle } from '../PageStyles';
-import TitleLogo from './TitleLogo';
-import kakao from '../../assets/images/kakao.svg';
-import git from '../../assets/images/github.svg';
-import { LoginBtn } from './LoginBtn';
+import React from "react";
+import CssBaseline from "@mui/material/CssBaseline";
+import Box from "@mui/material/Box";
+import Container from "@mui/material/Container";
+import { SignInStyle } from "../PageStyles";
+import TitleLogo from "./TitleLogo";
+import kakao from "../../assets/images/kakao.svg";
+import git from "../../assets/images/github.svg";
+import { LoginBtn } from "./LoginBtn";
 
 export default function SignIn() {
   return (
@@ -16,8 +16,18 @@ export default function SignIn() {
         <Box textAlign="center" width="100%">
           <TitleLogo />
           <Box sx={SignInStyle.BtnContainer}>
-            <LoginBtn title="카카오톡으로 시작하기" color="#191919" social="kakao" logo={kakao} />
-            <LoginBtn title="깃허브로 시작하기" color="white" social="github" logo={git} />
+            <LoginBtn
+              title="카카오톡으로 시작하기"
+              color="#191919"
+              social="kakao"
+              logo={kakao}
+            />
+            <LoginBtn
+              title="깃허브로 시작하기"
+              color="white"
+              social="github"
+              logo={git}
+            />
           </Box>
         </Box>
       </Box>


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex)  #220 

## 📝작업 내용

> 
### 1. 각 인풋들의 유효성 검사와 helperText 구현 완료했습니다
<img width="302" alt="image" src="https://github.com/Kernel360/f1-JDON-Frontend/assets/103630185/da8cfd7c-0746-47a6-8926-b3433b5bccc3">

### 2. 커피챗 생성 시 alert 띄우기
- 기존에는 사용자에게 취소, 확인 선택 권한을 부여했다면, 이제는 생성 성공 시 해당 커피챗으로 무조건 이동시키는 alert 창을 추가하였습니다

### 3. 인터셉터에 alert 창 추가
- 기존에는 로그인 에러 401이 발생하면 바로 로그인페이지로 이동시켰지만
- alert 창으로 "로그인이 필요한 서비스입니다" 라고 보여준 후 이동시키는 방식으로 변경하였습니다


### 4. 하단네비게이션에서 로그인 상태값 recoil로 변경
- 하단네비에서 로그인 하지 않았을 때는 -> '로그인', 로그인 했을 때는 '마이페이지' 를 보여주도록 구현하려는 의도였지만 가끔 제대로 동작하지 않아서 확인해보니 기존의 localStoarge에서 관리 중인 로그인 상태값을 사용하더라고요!
- 그래서 이부분 recoil을 통해 로그인 상태 확인하도로고 변경하였습니다


## 💬리뷰 요구사항(선택)
