### PR TITLE
🐛 Fix :  리뷰 api 호출 전에, 로그인 유무 확인해서 분기타도록 변경

### DIFF
--- a/src/components/common/BottomNav.jsx
+++ b/src/components/common/BottomNav.jsx
@@ -15,6 +15,7 @@ export default function BottomNav() {
   const location = useLocation();
   const [value, setValue] = useState(0);
   const userLogin = useRecoilValue(isLoggedInState).isLoginUser;
+  console.log(userLogin);
 
   useEffect(() => {
     switch (true) {

--- a/src/components/common/card/VideoCard.jsx
+++ b/src/components/common/card/VideoCard.jsx
@@ -1,26 +1,30 @@
-import * as React from 'react';
-import CardMedia from '@mui/material/CardMedia';
-import Typography from '@mui/material/Typography';
-import { Box } from '@mui/material';
-import heart from 'assets/icons/heart.svg';
-import heartFilled from 'assets/icons/heart_filled.svg';
-import person from 'assets/icons/person.svg';
-import { useState } from 'react';
-import { VideoCardStyle } from './CardStyle';
-import 'styles/animations.scss';
-import { postFavoritVideo } from 'api/api';
-import { useNavigate } from 'react-router-dom';
+import * as React from "react";
+import CardMedia from "@mui/material/CardMedia";
+import Typography from "@mui/material/Typography";
+import { Box } from "@mui/material";
+import heart from "assets/icons/heart.svg";
+import heartFilled from "assets/icons/heart_filled.svg";
+import person from "assets/icons/person.svg";
+import { useState } from "react";
+import { VideoCardStyle } from "./CardStyle";
+import "styles/animations.scss";
+import { postFavoritVideo } from "api/api";
+import { useNavigate } from "react-router-dom";
+import { useRecoilValue } from "recoil";
+import { isLoggedInState } from "recoil/atoms";
 
 function VideoCard({ data, myFavorite, onError }) {
-  const [isFavorite, setIsFavorite] = useState(myFavorite ? true : data.isFavorite);
+  const [isFavorite, setIsFavorite] = useState(
+    myFavorite ? true : data.isFavorite
+  );
 
-  const isLogin = localStorage.getItem('isLoggedInState');
+  const isLogin = useRecoilValue(isLoggedInState).isLoginUser;
   const navigate = useNavigate();
 
   const toggleFavoriteStatus = async (e) => {
     e.stopPropagation();
 
-    if (isLogin === 'false') {
+    if (!isLogin) {
       promptLogin();
       return;
     }
@@ -38,24 +42,29 @@ function VideoCard({ data, myFavorite, onError }) {
     }
   };
   const promptLogin = () => {
-    const confirmResult = window.confirm('찜하기는 로그인 후 이용할 수 있습니다. 로그인 하시겠습니까?');
+    const confirmResult = window.confirm(
+      "찜하기는 로그인 후 이용할 수 있습니다. 로그인 하시겠습니까?"
+    );
     if (confirmResult) {
-      navigate('/signin');
+      navigate("/signin");
     }
   };
 
   const goToLecture = () => {
-    window.open(data.lectureUrl, '_blank');
+    window.open(data.lectureUrl, "_blank");
   };
 
   return (
-    <Box sx={{ my: 1, pointer: 'cursor', position: 'relative' }} onClick={goToLecture}>
+    <Box
+      sx={{ my: 1, pointer: "cursor", position: "relative" }}
+      onClick={goToLecture}
+    >
       <CardMedia
         component="img"
         image={data.imageUrl}
         sx={{
-          borderRadius: '8px',
-          maxHeight: '230px',
+          borderRadius: "8px",
+          maxHeight: "230px",
         }}
       />
       <img
@@ -63,18 +72,21 @@ function VideoCard({ data, myFavorite, onError }) {
         alt="heart"
         onClick={toggleFavoriteStatus}
         style={{
-          position: 'absolute',
+          position: "absolute",
           top: 6,
           right: 6,
-          animation: data.isFavorite ? 'pop 0.3s ease' : 'none',
+          animation: data.isFavorite ? "pop 0.3s ease" : "none",
         }}
       />
       <Box sx={{ mt: 1 }}>
-        <Typography sx={VideoCardStyle.Instructor}>{data.instructor}</Typography>
+        <Typography sx={VideoCardStyle.Instructor}>
+          {data.instructor}
+        </Typography>
         <Typography sx={VideoCardStyle.Title}>{data.title}</Typography>
         <Box>
           <Typography fontWeight="600" color="#545459">
-            {data.price.toLocaleString()} <span style={{ fontSize: '14px' }}>원</span>
+            {data.price.toLocaleString()}{" "}
+            <span style={{ fontSize: "14px" }}>원</span>
           </Typography>
         </Box>
         <Typography sx={VideoCardStyle.StudentCount}>

--- a/src/pages/jd-detail/addReviewButton.jsx
+++ b/src/pages/jd-detail/addReviewButton.jsx
@@ -1,12 +1,8 @@
 import { Box } from "@mui/material";
 import { theme } from "styles/themeMuiStyle";
 import add from "assets/icons/review_add.svg";
-import { useRecoilValue } from "recoil";
-import { isLoggedInState } from "recoil/atoms";
 
 export const AddReviewButton = ({ openPopup }) => {
-  const loginState = useRecoilValue(isLoggedInState);
-  console.log(loginState);
   return (
     <Box
       sx={{

--- a/src/pages/jd-detail/useReviewPagination.jsx
+++ b/src/pages/jd-detail/useReviewPagination.jsx
@@ -1,15 +1,24 @@
 import { useState, useEffect } from "react";
 import { getReivew } from "../../api/api";
 import { useInView } from "react-intersection-observer";
+import { useRecoilValue } from "recoil";
+import { isLoggedInState } from "recoil/atoms";
+import { useNavigate } from "react-router-dom";
 
 export const useReviewPagination = (id) => {
+  const navigate = useNavigate();
   const [page, setPage] = useState(0);
   const [lastPage, setLastPage] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const [reviewData, setReviewData] = useState([]);
   const [ref, inView] = useInView();
+  const isLogin = useRecoilValue(isLoggedInState).isLoginUser;
 
   const fetchReviewData = async (reset = false) => {
+    if (!isLogin) {
+      promptLogin();
+      return;
+    }
     if (reset) {
       setPage(0);
       setReviewData([]);
@@ -29,6 +38,15 @@ export const useReviewPagination = (id) => {
       console.log(e);
     }
     setIsLoading(false);
+  };
+
+  const promptLogin = () => {
+    const confirmResult = window.confirm(
+      "리뷰 작성은 로그인 후 이용할 수 있습니다. 로그인 하시겠습니까?"
+    );
+    if (confirmResult) {
+      navigate("/signin");
+    }
   };
 
   useEffect(() => {


### PR DESCRIPTION
## #️⃣연관된 이슈

> #220 

## 📝작업 내용

> 

- 변경된점 
1. 리뷰 생성 버튼 클릭 시 alert -> confirm 창으로 변경
2. 기존에는 인터셉터로 401 에러 나는 api를 캐치하여 로그인 알림 창을 띄웠다면, 이번에는 api 호출하기 전 버튼을 클릭했을 시 바로 로그인 상태 값 확인

## 💬리뷰 요구사항(선택)
