### PR TITLE
♻️ Refactor : Header 공동 컴포넌트 수정

### DIFF
--- a/src/components/common/Header.jsx
+++ b/src/components/common/Header.jsx
@@ -1,9 +1,17 @@
 import { Box, Typography } from "@mui/material";
-import back from "../../assets/icons/btn_back.svg";
+import back from "assets/icons/btn_back.svg";
+import { useNavigate } from "react-router-dom";
 
-function Header({ title }) {
+/**
+ * @function Header - 각 하위 페이지별 상단에 존재하는 공통 레이아웃 컴포넌트입니다.
+ * @summary - 각 페이지별 상세페이지에서 default 페이지 (목록페이지)로 넘어갈 수 있는 버튼을 제공합니다.
+ * @param title - 이전 페이지의 위치를 나타내는 텍스트입니다. `ex) 목록 페이지로, 마이페이지로`
+ * @param url - 버튼을 눌렀을 때 이동할 라우터의 주소입니다.
+ */
+function Header({ title, url }) {
+  const navigate = useNavigate()
   const goBackHandler = () => {
-    window.history.back();
+    navigate(url);
   };
   return (
     <>
@@ -12,7 +20,7 @@ function Header({ title }) {
           onClick={goBackHandler}
           sx={{ py: 3, display: "flex", gap: 2, cursor: "pointer" }}
         >
-          <img src={back} alt="백" />
+          <img src={back} alt="뒤로가기 아이콘" />
           <Typography fontSize="1rem" fontWeight={400}>
             {title}
           </Typography>

--- a/src/constants/headerProps.js
+++ b/src/constants/headerProps.js
@@ -5,13 +5,22 @@
 
 // 커피챗 상세페이지 및 커피챗 생성 페이지
 export const COFFEE_CHILD = {
-    title: '커피챗 목록으로',
+    title: '커피챗 목록',
     url: '/coffee',
 }
-
+// 커피챗 - 수정화면에서 상세페이지로 이동하도록.
+export const COFFEE_CHILD_ID = {
+    title: '커피챗 상세페이지',
+    url : '/coffee/',
+}
+// 커피챗 - 마이페이지에서 타고 들어갈 시 다시 마이페이지로 오도록. (아직 적용 안됨.)
+export const COFFEE_MYPAGE_CHILD = {
+    title: '내 커피챗',
+    url: '/mypage/coffee',
+}
 // JD 상세 페이지
 export const JD_CHILD= {
-    title: 'JD-ON 목록으로',
+    title: 'JD-ON 목록',
     url: '/jd',
 }
 
@@ -21,8 +30,11 @@ export const MYPAGE_CHILD = {
     url: '/mypage',
 }
 
+
 // 회원탈퇴 페이지 
 export const USER_QUIT = {
     title: '내 정보 수정',
     url: '/mypage/infoedit',
 }
+
+

--- a/src/constants/headerProps.js
+++ b/src/constants/headerProps.js
@@ -1,0 +1,28 @@
+
+/**
+ * Header 공동 컴포넌트에 있는 버튼의 제목 및 라우팅 경로를 지정해주는 파일입니다.  
+ * */
+
+// 커피챗 상세페이지 및 커피챗 생성 페이지
+export const COFFEE_CHILD = {
+    title: '커피챗 목록으로',
+    url: '/coffee',
+}
+
+// JD 상세 페이지
+export const JD_CHILD= {
+    title: 'JD-ON 목록으로',
+    url: '/jd',
+}
+
+// 마이페이지 (찜, 커피챗, 정보수정)
+export const MYPAGE_CHILD = {
+    title: '마이페이지',
+    url: '/mypage',
+}
+
+// 회원탈퇴 페이지 
+export const USER_QUIT = {
+    title: '내 정보 수정',
+    url: '/mypage/infoedit',
+}

--- a/src/pages/coffee-detail/CoffeeDetail.jsx
+++ b/src/pages/coffee-detail/CoffeeDetail.jsx
@@ -9,6 +9,7 @@ import CoffeeDetailButtons from "./CoffeeDetailButtons";
 import { BeatLoader } from "react-spinners";
 import { useRecoilValue } from "recoil";
 import { isLoggedInState } from "recoil/atoms";
+import { COFFEE_CHILD } from "constants/headerProps";
 
 function CoffeeDetail() {
   const { id } = useParams();
@@ -16,7 +17,7 @@ function CoffeeDetail() {
   const [isLoading, setIsLoading] = useState(true);
   const loginState = useRecoilValue(isLoggedInState);
   const [isParticipant, setIsParticipant] = useState(false);
-
+  
   useEffect(() => {
     (async () => {
       setIsLoading(true);
@@ -57,7 +58,7 @@ function CoffeeDetail() {
   return (
     <Container maxWidth="md">
       <CssBaseline />
-      <Header title={coffeeChatData.title} />
+      <Header title={COFFEE_CHILD.title} url={COFFEE_CHILD.url}/>
       <HostInfoWithViewcount coffeeChatData={coffeeChatData} />
       <CoffeeChatInfo
         coffeeChatData={coffeeChatData}

--- a/src/pages/coffee-detail/UpdateCoffeeForm.jsx
+++ b/src/pages/coffee-detail/UpdateCoffeeForm.jsx
@@ -17,6 +17,7 @@ import {
 } from "api/api";
 import { useNavigate, useParams } from "react-router-dom";
 import { theme } from "styles/themeMuiStyle";
+import { COFFEE_CHILD_ID } from "constants/headerProps";
 
 function UpdateCoffeeForm() {
   const { id } = useParams();
@@ -28,13 +29,11 @@ function UpdateCoffeeForm() {
     openChatUrl: "",
   });
   const navigate = useNavigate();
-  console.log(id);
 
   useEffect(() => {
     (async () => {
       try {
         const res = await getCoffeeChatDetail(id);
-        console.log(res);
         setCoffeeChatData(res);
       } catch (error) {
         console.error("Error fetching coffee chat detail:", error);
@@ -98,7 +97,8 @@ function UpdateCoffeeForm() {
         sx={{ display: "flex", flexDirection: "column" }}
       >
         <CssBaseline />
-        <Header title="커피챗 오픈" />
+        <Header title={COFFEE_CHILD_ID.title}  url={COFFEE_CHILD_ID.url+id}/>
+
         <Box
           flexGrow={1}
           display="flex"

--- a/src/pages/coffeechat/CoffeeOpen.jsx
+++ b/src/pages/coffeechat/CoffeeOpen.jsx
@@ -7,6 +7,7 @@ import { registerCoffeeChat } from "api/api";
 import { useNavigate } from "react-router-dom";
 import { theme } from "styles/themeMuiStyle";
 import NewBtn from "components/common/new-btn/NewBtn";
+import { COFFEE_CHILD } from "constants/headerProps";
 
 function Coffeeopen() {
   const navigate = useNavigate();
@@ -115,7 +116,7 @@ function Coffeeopen() {
   return (
     <Container maxWidth="sm" display="flex" flexDirection="column">
       <CssBaseline />
-      <Header title="커피챗 오픈" />
+      <Header title={COFFEE_CHILD.title} url={COFFEE_CHILD.url} />
       <Box
         flexGrow={1}
         display="flex"

--- a/src/pages/jd-detail/JdDetail.jsx
+++ b/src/pages/jd-detail/JdDetail.jsx
@@ -1,12 +1,13 @@
 import { Container, CssBaseline } from "@mui/material";
 import Header from "components/common/Header";
 import { CategoryTab } from "./CategoryTab";
+import { JD_CHILD } from "constants/headerProps";
 
 export function JdDetail() {
   return (
     <Container maxWidth="md">
       <CssBaseline />
-      <Header title="jd 상세" />
+      <Header title={JD_CHILD.title} url={JD_CHILD.url}/>
       <CategoryTab />
     </Container>
   );

--- a/src/pages/mypage/FavoritesVideo.jsx
+++ b/src/pages/mypage/FavoritesVideo.jsx
@@ -5,6 +5,7 @@ import VideoCard from "components/common/card/VideoCard";
 import { getFavoritVideo } from "api/api";
 import Header from "components/common/Header";
 import Pagenation from "components/common/Pagenation";
+import { MYPAGE_CHILD } from "constants/headerProps";
 
 export default function FavoritesVideo() {
   const [datas, setDatas] = useState(null);
@@ -64,7 +65,7 @@ export default function FavoritesVideo() {
         pb: 10,
       }}
     >
-      <Header title={"찜"} />
+      <Header title={MYPAGE_CHILD.title} url={MYPAGE_CHILD.url} />
       <Grid container spacing={{ xs: 2, md: 2 }} sx={{ px: 2, py: 1 }}>
         {datas && datas.length > 0 ? (
           datas.map((item, index) => (

--- a/src/pages/mypage/InfoEdit.jsx
+++ b/src/pages/mypage/InfoEdit.jsx
@@ -16,6 +16,7 @@ import NewDayPicker from "components/common/new-daypicker/NewDayPicker";
 import TotalInputForm from "components/common/total-input-form/TotalInputForm";
 import { OptionButton, infoBasicStyles } from "../info/InfoStyles";
 import { NO_SC, NO_ADMIN, NO_SPACE_BAR } from "constants/nickname";
+import { MYPAGE_CHILD } from "constants/headerProps";
 
 const GENDERS = ["남성", "여성"];
 
@@ -181,7 +182,7 @@ export default function InfoEdit() {
       }}
     >
       <CssBaseline />
-      <Header title="정보수정" />
+      <Header title={MYPAGE_CHILD.title} url={MYPAGE_CHILD.url} />
       <Box
         sx={{
           flexGrow: 1,

--- a/src/pages/mypage/MyCoffeeChat.jsx
+++ b/src/pages/mypage/MyCoffeeChat.jsx
@@ -8,6 +8,7 @@ import Pagenation from "components/common/Pagenation";
 import { MainStyles } from "../PageStyles";
 import { useRecoilValue } from "recoil";
 import { kindOfJdState } from "recoil/atoms";
+import { MYPAGE_CHILD } from "constants/headerProps";
 
 export default function MyCoffeeChat() {
   const [value, setValue] = useState("1");
@@ -58,7 +59,7 @@ export default function MyCoffeeChat() {
         minHeight: "100vh",
       }}
     >
-      <Header title={"커피챗"} />
+      <Header title={MYPAGE_CHILD.title} url={MYPAGE_CHILD.url}/>
       <Box mt={2}>
         <TabContext value={value}>
           <Box sx={{ borderBottom: 1, borderColor: "divider" }}>

--- a/src/pages/mypage/Withdrawal.jsx
+++ b/src/pages/mypage/Withdrawal.jsx
@@ -5,6 +5,7 @@ import { Button, Container } from "@mui/material";
 import { buttonStyle } from "components/common/navigation-btn/NavigationBtnStyles";
 import { useNavigate } from "react-router-dom";
 import { deleteMember } from "api/api";
+import { USER_QUIT } from "constants/headerProps";
 
 const isValidEmail = (email) => {
   const emailRegex = /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,4}$/i;
@@ -28,12 +29,15 @@ export default function Withdrawal() {
 
   const handleSaveChanges = async () => {
     try {
-      console.log("최종Email", email);
-      const res = await deleteMember();
-      if (res) {
+      const lastChance = window.confirm(
+        `회원탈퇴 후 같은 소셜 계정으로 재 가입이 불가능합니다. \n 그래도 탈퇴하시겠습니까?`
+      );
+      if (lastChance) {
+        const res = await deleteMember();
         console.log(`${res || null}회원탈퇴합니다`);
 
         localStorage.setItem("isLoggedInState", false);
+        alert('회원탈퇴가 정상적으로 진행되었습니다.')
         navigate("/");
       }
     } catch (error) {
@@ -51,13 +55,13 @@ export default function Withdrawal() {
         paddingX: "29px",
       }}
     >
-      <Header title={"회원 탈퇴"} />
+      <Header title={USER_QUIT.title} url={USER_QUIT.url} />
 
       <InputField
         label={"이메일"}
         name={"email"}
         type={"email"}
-        placeholder={"이메일을 입력해주세요"}
+        placeholder={"가입한 소셜 계정의 이메일을 입력해주세요"}
         value={email}
         onChange={(name, value) => handleEmailChange(value)}
         error={emailError !== ""}
@@ -72,7 +76,7 @@ export default function Withdrawal() {
         mb={1}
         sx={{
           ...buttonStyle.Button,
-          ...(emailError !== "" || email == "" ? {} : buttonStyle.ActiveButton),
+          ...(emailError !== "" || email === "" ? {} : buttonStyle.ActiveButton),
         }}
       >
         탈퇴


### PR DESCRIPTION
## #️⃣연관된 이슈

close #240
close #214 

## 📝작업 내용

각 상세페이지 및 하위페이지별로 이전 페이지로 돌아갈 수 있도록 
고정된 url을 직접 부여하고, 사용자의 이해를 도울 수 있도록 
뒤로가기 버튼의 명칭을 이전 페이지가 유추될 수 있도록 바꿨습니다.

<br/>

### 커피챗 상세 페이지에서 목록으로 갈 수 있는 버튼 추가 &
### 커피챗 상세 url을 통해 직접 접근한 경우 다른 화면으로 접근 불가문제 해결
![3](https://github.com/Kernel360/f1-JDON-Frontend/assets/122848687/1dba9ea6-483c-4fb0-920e-0b67e1ef7e92)



## 💬리뷰 요구사항(선택)
