### PR TITLE
🐛 Fix : main화면 api 무한호출 에러 수정 및 로그인 후 이전페이지로 이동기능 추가

### DIFF
--- a/src/components/common/card/VideoCard/index.jsx
+++ b/src/components/common/card/VideoCard/index.jsx
@@ -56,7 +56,7 @@ function VideoCard({ data, onSuccess, myFavorite, onError }) {
 
   const promptLogin = () => {
     const confirmResult = window.confirm(
-      '찜은 로그인 후 이용할 수 있습니다. \n 로그인 페이지로 이동하시겠습니까?',
+      '찜은 로그인 후 이용할 수 있습니다. \n로그인 페이지로 이동하시겠습니까?',
     );
     if (confirmResult) {
       navigate('/signin');

--- a/src/components/common/constant.jsx
+++ b/src/components/common/constant.jsx
@@ -3,7 +3,7 @@ import { useNavigate } from 'react-router-dom';
 export const PromptLogin = () => {
   const navigate = useNavigate();
   const userAgrees = window.confirm(
-    '찜은 로그인 후 이용할 수 있습니다. \n 로그인 페이지로 이동하시겠습니까?',
+    '찜은 로그인 후 이용할 수 있습니다. \n로그인 페이지로 이동하시겠습니까?',
   );
   if (userAgrees) navigate('/signin');
 };

--- a/src/pages/coffeechats/FiltersAndButton.jsx
+++ b/src/pages/coffeechats/FiltersAndButton.jsx
@@ -11,7 +11,7 @@ function FiltersAndButton({ sortData, kindOfJd, onChange }) {
 
   const handleConfirm = () => {
     window.confirm(
-      '커피챗 생성은 로그인 후 사용하실 수 있습니다. \n 로그인페이지로 이동하시겠습니까??',
+      '커피챗 생성은 로그인 후 사용하실 수 있습니다. \n로그인 페이지로 이동하시겠습니까??',
     ) && navigate('/signin');
   };
 

--- a/src/pages/coffeechats/FiltersAndButton.jsx
+++ b/src/pages/coffeechats/FiltersAndButton.jsx
@@ -1,18 +1,24 @@
 import { Box, Button } from '@mui/material';
 
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { useRecoilValue } from 'recoil';
 import { isLoggedInState } from 'recoil/atoms';
 import { Filters } from './components/Filters';
 
 function FiltersAndButton({ sortData, kindOfJd, onChange }) {
   const navigate = useNavigate();
+  const { pathname } = useLocation();
   const isLogin = useRecoilValue(isLoggedInState).isLoginUser;
 
   const handleConfirm = () => {
-    window.confirm(
-      '커피챗 생성은 로그인 후 사용하실 수 있습니다. \n로그인 페이지로 이동하시겠습니까?',
-    ) && navigate('/signin');
+    if (
+      window.confirm(
+        '커피챗 생성은 로그인 후 사용하실 수 있습니다. \n로그인 페이지로 이동하시겠습니까?',
+      )
+    ) {
+      localStorage.setItem('pathname', pathname);
+      navigate('/signin');
+    }
   };
 
   const handleOpenCoffee = () => {

--- a/src/pages/coffeechats/FiltersAndButton.jsx
+++ b/src/pages/coffeechats/FiltersAndButton.jsx
@@ -11,7 +11,7 @@ function FiltersAndButton({ sortData, kindOfJd, onChange }) {
 
   const handleConfirm = () => {
     window.confirm(
-      '커피챗 생성은 로그인 후 사용하실 수 있습니다. \n로그인 페이지로 이동하시겠습니까??',
+      '커피챗 생성은 로그인 후 사용하실 수 있습니다. \n로그인 페이지로 이동하시겠습니까?',
     ) && navigate('/signin');
   };
 

--- a/src/pages/jd-detail/CategoryTab.jsx
+++ b/src/pages/jd-detail/CategoryTab.jsx
@@ -5,7 +5,7 @@ import { TabForInfo } from './TabForInfo';
 import { TabForReview } from './TabForReview';
 import { MainStyles } from '../PageStyles';
 import { getJdDetail } from 'api/api';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import { useRecoilValue } from 'recoil';
 import { isLoggedInState } from 'recoil/atoms';
 
@@ -27,7 +27,7 @@ function TabPanelItem({ children, value }) {
 
 export function CategoryTab() {
   const navigate = useNavigate();
-
+  const { pathname } = useLocation();
   const [value, setValue] = useState('1');
   const [jdData, setJdData] = useState({});
   const [reviewNum, setReviewNum] = useState(0);
@@ -38,8 +38,10 @@ export function CategoryTab() {
 
   const handleTabChange = (e, newValue) => {
     if (isLogin === false && newValue === '2') {
-      window.confirm('리뷰는 로그인 후 조회할 수 있습니다. \n로그인 하시겠습니까?') &&
+      if (window.confirm('리뷰는 로그인 후 조회할 수 있습니다. \n로그인 하시겠습니까?')) {
+        localStorage.setItem('pathname', pathname);
         navigate('/signin');
+      }
     } else {
       setValue(newValue);
     }

--- a/src/pages/mainpage/StickyTabSection.jsx
+++ b/src/pages/mainpage/StickyTabSection.jsx
@@ -44,7 +44,7 @@ function StickyTabSection({ selectedChip, setSelectedChip }) {
 
   const handleConfirm = () => {
     window.confirm(
-      '내 맞춤 키워드는 로그인 후에 확인 하실 수 있습니다. \n 로그인페이지로 이동하시겠습니까?',
+      '내 맞춤 키워드는 로그인 후에 확인 하실 수 있습니다. \n로그인 페이지로 이동하시겠습니까?',
     ) && navigate('/signin');
   };
 

--- a/src/pages/mainpage/useLoadData.jsx
+++ b/src/pages/mainpage/useLoadData.jsx
@@ -9,29 +9,37 @@ export function useLoadData() {
   const [lectureList, setLectureList] = useState([]);
   const [jdList, setJdList] = useState([]);
   const [isInitialLoad, setIsInitialLoad] = useState(true);
+  const [isAPiError, setApiError] = useState(false);
 
   const loadData = useCallback(
     async (keyword, userSelected) => {
-      const res = await fetchLectureData(encodeURIComponent(keyword));
-      setLectureList(res.lectureList);
-      setJdList(res.jdList);
+      try {
+        const res = await fetchLectureData(encodeURIComponent(keyword));
+        setLectureList(res.lectureList);
+        setJdList(res.jdList);
 
-      if (isInitialLoad) {
-        setSelectedChip({ keyword: res.keyword, userSelected });
-        setIsInitialLoad(false);
+        if (isInitialLoad) {
+          setSelectedChip({ keyword: res.keyword, userSelected });
+          setIsInitialLoad(false);
+        }
+        setApiError(false);
+      } catch (error) {
+        console.error('Error while fetching data:', error);
+        setIsInitialLoad(true);
+        setApiError(true);
       }
     },
     [isInitialLoad],
   );
 
   useEffect(() => {
-    isInitialLoad && loadData('', false);
+    if (isInitialLoad) loadData('', false);
+    else return;
+
     if (selectedChip.userSelected && selectedChip.keyword) {
       loadData(selectedChip.keyword, true);
-    } else if (!selectedChip.keyword) {
-      setIsInitialLoad(true);
     }
-  }, [isInitialLoad, selectedChip, loadData]);
+  }, [isInitialLoad, selectedChip, loadData, isAPiError]);
 
   return { selectedChip, setSelectedChip, lectureList, jdList };
 }

--- a/src/pages/sign-in/RedirectPage.jsx
+++ b/src/pages/sign-in/RedirectPage.jsx
@@ -7,7 +7,7 @@ const RedirectPage = () => {
   const location = useLocation();
   const navigate = useNavigate();
   const [, setData] = useRecoilState(userInfo);
-
+  let path = localStorage.getItem('pathname');
   useEffect(() => {
     localStorage.setItem('isLoggedInState', false);
     const searchParams = new URLSearchParams(location.search);
@@ -19,10 +19,16 @@ const RedirectPage = () => {
       navigate('/info');
       setData((prev) => ({ ...prev, encrypted: value, hmac: hmac }));
     } else {
-      navigate('/');
+      if (path) {
+        navigate(path);
+        localStorage.removeItem('pathname');
+      } else {
+        navigate('/');
+      }
+
       localStorage.setItem('isLoggedInState', true);
     }
-  }, [location, navigate, setData]);
+  }, [location, navigate, setData, path]);
 
   return (
     <div>


### PR DESCRIPTION
## #️⃣연관된 이슈
close #302 
close #303 

## 📝작업 내용

### 메인화면에서 api를 무한 호출하는 문제를 해결했습니다.
![28](https://github.com/Kernel360/f1-JDON-Frontend/assets/122848687/3826bb20-b5d4-4261-800b-f49638e3a8bc)
### 추가로, api가 응답해도 두번씩 api를 요청하는 오류를 수정했습니다.

<br/>


### 로그인 후 이전페이지로 리다이렉트 되도록 했습니다.
![29](https://github.com/Kernel360/f1-JDON-Frontend/assets/122848687/dc7bf5f5-dac7-40b6-a685-23c2b1501e3b)

### 리뷰 탭, 커피챗 생성버튼 등에 적용되었습니다.

## 💬리뷰 요구사항(선택)
