### PR TITLE
🐛 Fix : 리뷰 api 호출 부분 수정 & 커피챗 수정 에러 메세지 alert 띄우기

### DIFF
--- a/src/components/common/new-btn/RoundButton.jsx
+++ b/src/components/common/new-btn/RoundButton.jsx
@@ -22,6 +22,7 @@ function RoundButton({ title, onClick }) {
     e.preventDefault();
     e.stopPropagation();
     onClick();
+  setIsHovered(false)
   };
   return (
     <button

--- a/src/pages/coffeechats/create-coffeechats/index.jsx
+++ b/src/pages/coffeechats/create-coffeechats/index.jsx
@@ -50,7 +50,6 @@ function Coffeeopen() {
   useEffect(() => {
     const memData = async () => {
       const res = await getMemberInfo();
-      console.log(res);
       setNickName(res.data.nickname);
       setJobId(res.data.jobCategoryId);
     };

--- a/src/pages/coffeechats/create-coffeechats/styles.js
+++ b/src/pages/coffeechats/create-coffeechats/styles.js
@@ -22,5 +22,6 @@ export const noticeMsg = {
   p: 0,
   fontSize: '12px',
   alignItems: 'center',
-  color: '#69696E',
+	color: '#69696E',
+  fontWeight:400
 };

--- a/src/pages/coffeechats/update-coffeechats/index.jsx
+++ b/src/pages/coffeechats/update-coffeechats/index.jsx
@@ -3,7 +3,7 @@ import Header from 'components/common/Header';
 import NewInput from 'components/common/new-input/NewInput';
 import NewDayPicker from 'components/common/new-daypicker/NewDayPicker';
 import { useEffect } from 'react';
-import { getCoffeeChatDetail, registerCoffeeChat, updateCoffeechat } from 'api/api';
+import { getCoffeeChatDetail, updateCoffeechat } from 'api/api';
 import { useNavigate, useParams } from 'react-router-dom';
 import { theme } from 'styles/themeMuiStyle';
 import NewBtn from 'components/common/new-btn/NewBtn';
@@ -45,14 +45,8 @@ function UpdateCoffeeForm() {
   const hanldeRegister = async (e) => {
     e.preventDefault();
     try {
-      if (id) {
-        await updateCoffeechat(id, formValue);
-        alert('커피챗이 수정되었습니다.');
-
-      } else {
-        await registerCoffeeChat(formValue);
-        alert('커피챗이 생성되었습니다.');
-      }
+      await updateCoffeechat(id, formValue);
+      alert('커피챗이 수정되었습니다.')
       navigate(`/coffee/${id}`);
     } catch (error) {
       const { message } = error.response.data;

--- a/src/pages/coffeechats/update-coffeechats/index.jsx
+++ b/src/pages/coffeechats/update-coffeechats/index.jsx
@@ -37,7 +37,6 @@ function UpdateCoffeeForm() {
         if (error.response.status) {
           navigate('/404');
         }
-
         console.error('Error fetching coffee chat detail:', error);
       }
     })();
@@ -49,12 +48,15 @@ function UpdateCoffeeForm() {
       if (id) {
         await updateCoffeechat(id, formValue);
         alert('커피챗이 수정되었습니다.');
+
       } else {
         await registerCoffeeChat(formValue);
         alert('커피챗이 생성되었습니다.');
       }
       navigate(`/coffee/${id}`);
     } catch (error) {
+      const { message } = error.response.data;
+      alert(message);
       console.error('Error fetching hot skills:', error);
     }
   };

--- a/src/pages/jd-detail/ReviewItem.jsx
+++ b/src/pages/jd-detail/ReviewItem.jsx
@@ -28,7 +28,7 @@ export function ReviewItem({ review, isWritter, deleteReviewAndUpdate }) {
           {review.createdDate}
         </Typography>
       </Box>
-      <Typography variant="body3" component="p" color="#545459" fontSize={14}>
+      <Typography variant="body3" component="p" color="#545459" fontSize={14} fontWeight={500}>
         {review.content}
       </Typography>
       {isWritter && (

--- a/src/pages/jd-detail/TabForReview.jsx
+++ b/src/pages/jd-detail/TabForReview.jsx
@@ -15,9 +15,10 @@ export function TabForReview({ id, setReviewNum }) {
   const loginState = useRecoilValue(isLoggedInState);
   const { isLoading, reviewData, ref, fetchReviewData } = useReviewPagination(id);
 
-  const { addReviewAndUpdate } = useAddReview(id, setReviewNum, fetchReviewData, closePopup);
+  const { addReviewAndUpdate } = useAddReview(id, setReviewNum, fetchReviewData,closePopup);
 
   const { deleteReviewAndUpdate } = useDeleteReview(setReviewNum, fetchReviewData);
+
 
   return (
     <>

--- a/src/pages/jd-detail/useReviewPagination.jsx
+++ b/src/pages/jd-detail/useReviewPagination.jsx
@@ -4,49 +4,43 @@ import { useInView } from 'react-intersection-observer';
 
 export const useReviewPagination = (id) => {
   const [reviewId, setReviewId] = useState('');
-  const [lastPage, setLastPage] = useState(false);
-  const [isLoading, setIsLoading] = useState(false);
   const [reviewData, setReviewData] = useState([]);
+  const [isLastPage,setIsLastPage]=useState(false)
   const [ref, inView] = useInView();
 
   const fetchReviewData = useCallback(
-    async (reset = false) => {
+     async (reset = false) => {
       if (reset) {
         setReviewId('');
         setReviewData([]);
-        setLastPage(false);
+        setIsLastPage(false);
       }
-      if (isLoading || lastPage) return;
-      setIsLoading(true);
-
+      if(isLastPage)return
       try {
         const res = await getReivew(id, reviewId);
-        setReviewData((prev) => [...prev, ...res.content]);
-        if (res.content.length > 0) {
+        setReviewData((prev) => [...prev, ...res.content]||[]);
+        if (!res.pageInfo.empty) {
           const newReviewId = res.content[res.content.length - 1].id;
           setReviewId(newReviewId);
         }
         if (res.pageInfo.last) {
-          setLastPage(true);
-        }
+        setIsLastPage(true)
+      }
       } catch (e) {
         console.error(e);
       }
-      setIsLoading(false);
-    },
-    [id, reviewId, isLoading, lastPage],
-  );
+    }, [id,reviewId,isLastPage]
+  )
 
   useEffect(() => {
-    if ((inView && !isLoading) || reviewId) {
+    if (inView) {
       fetchReviewData();
     }
-  }, [inView, reviewId, isLoading, fetchReviewData]);
+  }, [inView, reviewId, fetchReviewData]);
 
   return {
-    isLoading,
     reviewData,
     ref,
-    fetchReviewData,
+    fetchReviewData
   };
 };


### PR DESCRIPTION
## #️⃣연관된 이슈

> #269 #285

## 📝작업 내용

> 
### 1. 리뷰api 호출 수정
- 기존에 스크롤 여부랑 상관없이 모든 리뷰에 대한 api가 한번에 요청이 되었다면
- 스크롤을 할때마다 하나씩 요청되도록 수정하였습니다
( 구현은 했지만 이렇게 요청되어야 하는게 맞는지는 확인을 해봐야할 것 같습니다! )

### 2. 커피챗 수정 오류 발생 시 오류메세지를 alert 창으로 보여주기
- 현재 모든 인풋에 유효성 검사를 적용해놓아서 유효성 검사 통과를 못할 시에 수정버튼 비활성화를 해놓아서 문제가 없었지만
만약 오류가 만약 발생했을 시에 사용자에게 오류 내용을 알려주기 위하여 alert 창을 추가하였습니다

- 에러 응답 데이터의 메세지 값 그대로 띄웁니다

```jsx
     await updateCoffeechat(id, formValue);
      alert('커피챗이 수정되었습니다.')
      navigate(`/coffee/${id}`);
    } catch (error) {
      const { message } = error.response.data;
      alert(message);
```

## 💬리뷰 요구사항(선택)
