### PR TITLE
🐛 Fix :  키워드 값 localStorage 저장

### DIFF
--- a/src/components/common/BottomNav.jsx
+++ b/src/components/common/BottomNav.jsx
@@ -42,6 +42,7 @@ export default function BottomNav() {
     setValue(newValue);
     localStorage.removeItem('filters');
     localStorage.removeItem('page');
+    localStorage.removeItem('keyword');
     switch (newValue) {
       case 0:
         navigate('/');

--- a/src/components/common/search-bar/HeaderWithSearchBar.jsx
+++ b/src/components/common/search-bar/HeaderWithSearchBar.jsx
@@ -1,5 +1,6 @@
 import SearchBar from 'components/common/search-bar';
 import logo from 'assets/images/logo.svg';
+import { useEffect } from 'react';
 
 function HeaderWithSearchBar({
   setSelectedChip,
@@ -8,12 +9,9 @@ function HeaderWithSearchBar({
   검색어,
   isSearchBarTrue = true,
 }) {
-  // const [search, setSearch] = useState(검색어);
-
-  // const handleSearchChange = (e) => {
-  //   const newSearch = e.target.value;
-  //   set검색어(newSearch);
-  // };
+  useEffect(() => {
+    검색어 && localStorage.setItem('keyword', JSON.stringify(검색어));
+  }, [검색어]);
 
   return (
     <>

--- a/src/components/common/search-bar/index.jsx
+++ b/src/components/common/search-bar/index.jsx
@@ -5,7 +5,8 @@ import SelectOption from './SelectOption';
 import { useState } from 'react';
 
 function SearchBar({ searchOptions, setSelectedChip, set검색어 }) {
-  const [실시간키워드, set실시간키워드] = useState('');
+  const prevKeyword = JSON.parse(localStorage.getItem('keyword'));
+  const [실시간키워드, set실시간키워드] = useState(prevKeyword || '');
   const handleKeyDown = (e) => {
     if (e.key === 'Enter' && e.nativeEvent.isComposing === false) {
       if (searchOptions) {

--- a/src/pages/coffeechats/coffeechat-list/index.jsx
+++ b/src/pages/coffeechats/coffeechat-list/index.jsx
@@ -19,7 +19,8 @@ export function Coffee() {
   const filterValues = JSON.parse(localStorage.getItem('filters') || '{}');
   const [sortData, setSortData] = useState({ ...defaultSortData, ...filterValues });
   const [currentPage, setCurrentPage] = useState(pageNum || 1);
-  const [검색어, set검색어] = useState('');
+  const prevKeyword = JSON.parse(localStorage.getItem('keyword'));
+  const [검색어, set검색어] = useState(prevKeyword || '');
   // 추후 스켈레톤 UI 반영 시 지울 내용입니다.
   const [foundTxt, setFoundTxt] = useState('커피챗 정보 불러오는 중..');
   const { coffeeData } = useFetchCoffeeData(currentPage, sortData, 검색어);

--- a/src/pages/coffeechats/hooks/useFetchCoffeeData.jsx
+++ b/src/pages/coffeechats/hooks/useFetchCoffeeData.jsx
@@ -3,7 +3,7 @@ import { getCoffeeChat } from 'api/api';
 import { useRecoilState } from 'recoil';
 import { coffeeChatListState } from 'recoil/atoms';
 
-const useFetchCoffeeData = (currentPage, sortData, searchKeyword) => {
+const useFetchCoffeeData = (currentPage, sortData, 검색어) => {
   const [coffeeData, setCoffeeData] = useRecoilState(coffeeChatListState);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
@@ -16,7 +16,7 @@ const useFetchCoffeeData = (currentPage, sortData, searchKeyword) => {
         sortData.pageSize || 12,
         sortData.sort,
         sortData.jobCategory,
-        searchKeyword,
+        검색어,
       );
       setCoffeeData(data.data.data);
       setError(null);
@@ -29,9 +29,10 @@ const useFetchCoffeeData = (currentPage, sortData, searchKeyword) => {
   };
 
   useEffect(() => {
+    console.log(검색어);
     fetchCoffeeData();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [currentPage, sortData, searchKeyword]);
+  }, [currentPage, sortData, 검색어]);
 
   return { coffeeData, loading, error };
 };

--- a/src/pages/coffeechats/hooks/useFetchCoffeeData.jsx
+++ b/src/pages/coffeechats/hooks/useFetchCoffeeData.jsx
@@ -29,7 +29,6 @@ const useFetchCoffeeData = (currentPage, sortData, 검색어) => {
   };
 
   useEffect(() => {
-    console.log(검색어);
     fetchCoffeeData();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [currentPage, sortData, 검색어]);


### PR DESCRIPTION
## #️⃣연관된 이슈

> 

## 📝작업 내용

> 
저번 pr 에서 추가한 커피챗 검색 기능에서 같은 도메인 내에서 검색값 유지 기능을 구현하였지만 저번 필터와 비슷하게 검색바에는 키워드가 유지되지만 데이터 호출할 때는 풀려버리는 문제가 있었습니다

원래는 Searchbar컴포넌트에서만 로컬스토리지의 값을 불러왔지만 사실상 데이터 패칭하는 부분이 이쪽이에요
그래서 해당 컴포넌트에서도 로컬스토리지의 값을 불러와서 적용해주어야 했습니다

```jsx
export function Coffee() {
...
  const prevKeyword = JSON.parse(localStorage.getItem('keyword'));
  const [검색어, set검색어] = useState(prevKeyword || '');
```

## 💬리뷰 요구사항(선택)
