### PR TITLE
✨ Feat : 검색어 길이제한 유효성 검사 추가 및 clear버튼 추가

### DIFF
--- a/src/components/common/search-bar/HeaderWithSearchBar.jsx
+++ b/src/components/common/search-bar/HeaderWithSearchBar.jsx
@@ -13,6 +13,7 @@ function HeaderWithSearchBar({
   const navigate = useNavigate();
 
   const imgHandler = () => {
+    localStorage.setItem('keyword', JSON.stringify(''));
     navigate('/');
   };
 

--- a/src/components/common/search-bar/HeaderWithSearchBar.jsx
+++ b/src/components/common/search-bar/HeaderWithSearchBar.jsx
@@ -22,8 +22,14 @@ function HeaderWithSearchBar({
 
   return (
     <>
-      <div onClick={imgHandler} style={{ cursor: 'pointer' }}>
-        <img src={logo} alt="logo" width={80} style={{ height: 50, marginTop: 10 }} />
+      <div>
+        <img
+          src={logo}
+          alt="logo"
+          width={80}
+          style={{ height: 50, marginTop: 10, cursor: 'pointer' }}
+          onClick={imgHandler}
+        />
       </div>
       {isSearchBarTrue ? (
         <SearchBar

--- a/src/components/common/search-bar/SearchBarStyles.js
+++ b/src/components/common/search-bar/SearchBarStyles.js
@@ -1,6 +1,8 @@
 export const SearchTextFiled = () => ({
+  position: 'relative',
   background: '#F5F5F7',
   borderRadius: '10px',
+  height: '52px',
   margin: '12px auto',
   '& .MuiOutlinedInput-root': {
     margin: '2px 0',
@@ -12,8 +14,20 @@ export const SearchTextFiled = () => ({
 });
 
 export const SearchContainer = () => ({
+  zIndex: 'auto',
+  position: 'relative',
   padding: '0 !important',
   '& .MuiInputBase-input': {
     padding: '12px',
   },
+});
+
+export const SearchResetBtn = () => ({
+  position: 'absolute',
+  left: '0',
+  bottom: '-10%',
+
+  color: '#f84d4d',
+
+  fontWeight: '300',
 });

--- a/src/components/common/search-bar/index.jsx
+++ b/src/components/common/search-bar/index.jsx
@@ -41,6 +41,12 @@ function SearchBar({ searchOptions, setSelectedChip, set검색어 }) {
     set실시간키워드('');
   };
 
+  const keywordValidate = (keyword) => {
+    if (!searchOptions && keyword.length > 20) return '검색어는 20자 이하여야 합니다.';
+    if (keyword.length > 50) return '검색어는 50자 이하여야 합니다.';
+    return '';
+  };
+
   return (
     <Container maxWidth="md" sx={SearchContainer}>
       <TextField
@@ -67,15 +73,7 @@ function SearchBar({ searchOptions, setSelectedChip, set검색어 }) {
           ),
         }}
       />
-      <Box sx={SearchResetBtn}>
-        {searchOptions
-          ? 실시간키워드.length > 50
-            ? '검색어는 50자 이하여야 합니다.'
-            : ''
-          : 실시간키워드.length > 20
-            ? '검색어는 20자 이하여야 합니다.'
-            : ''}
-      </Box>
+      <Box sx={SearchResetBtn}>{keywordValidate(실시간키워드)}</Box>
     </Container>
   );
 }

--- a/src/components/common/search-bar/index.jsx
+++ b/src/components/common/search-bar/index.jsx
@@ -10,7 +10,6 @@ function SearchBar({ searchOptions, setSelectedChip, set검색어 }) {
   const { pathname } = useLocation();
   const prevKeyword = JSON.parse(localStorage.getItem('keyword')) || '';
   const [실시간키워드, set실시간키워드] = useState(prevKeyword || '');
-
   const placeholder = pathname === '/' ? '기술 키워드를 입력하세요' : '검색어를 입력하세요';
 
   const handleKeyDown = (e) => {

--- a/src/components/common/search-bar/index.jsx
+++ b/src/components/common/search-bar/index.jsx
@@ -1,18 +1,33 @@
-import { Container, TextField, InputAdornment } from '@mui/material';
+import { Container, TextField, InputAdornment, IconButton, Box } from '@mui/material';
 import SearchIcon from '@mui/icons-material/Search';
-import { SearchContainer, SearchTextFiled } from './SearchBarStyles';
+import CancelIcon from '@mui/icons-material/Cancel';
+import { SearchContainer, SearchResetBtn, SearchTextFiled } from './SearchBarStyles';
 import SelectOption from './SelectOption';
 import { useState } from 'react';
 import { useLocation } from 'react-router-dom';
 
 function SearchBar({ searchOptions, setSelectedChip, set검색어 }) {
   const { pathname } = useLocation();
-  const prevKeyword = JSON.parse(localStorage.getItem('keyword'));
+  const prevKeyword = JSON.parse(localStorage.getItem('keyword')) || '';
   const [실시간키워드, set실시간키워드] = useState(prevKeyword || '');
+
+  const placeholder = pathname === '/' ? '기술 키워드를 입력하세요' : '검색어를 입력하세요';
+
   const handleKeyDown = (e) => {
     if (e.key === 'Enter' && e.nativeEvent.isComposing === false) {
+      // JD-ON, 커피챗 페이지
       if (searchOptions) {
+        if (실시간키워드.length > 50) {
+          alert('50자 미만의 키워드만 검색 가능합니다.');
+          return;
+        }
         set검색어(실시간키워드);
+        return;
+      }
+
+      // 메인페이지
+      if (실시간키워드.length > 20) {
+        alert('20자 미만의 키워드만 검색 가능합니다.');
         return;
       }
       setSelectedChip((prev) => ({
@@ -23,12 +38,16 @@ function SearchBar({ searchOptions, setSelectedChip, set검색어 }) {
     }
   };
 
+  const keywordResetHandler = () => {
+    set실시간키워드('');
+  };
+
   return (
     <Container maxWidth="md" sx={SearchContainer}>
       <TextField
         fullWidth
         value={실시간키워드}
-        placeholder="검색어를 입력하세요"
+        placeholder={placeholder}
         onChange={(e) => {
           set실시간키워드(e.target.value);
         }}
@@ -42,8 +61,22 @@ function SearchBar({ searchOptions, setSelectedChip, set검색어 }) {
               <SearchIcon sx={{ color: '#BCBCC4' }} />
             </InputAdornment>
           ),
+          endAdornment: 실시간키워드.length > 0 && (
+            <IconButton aria-label="delete" size="small" onClick={keywordResetHandler}>
+              <CancelIcon />
+            </IconButton>
+          ),
         }}
       />
+      <Box sx={SearchResetBtn}>
+        {searchOptions
+          ? 실시간키워드.length > 50
+            ? '검색어는 50자 이하여야 합니다.'
+            : ''
+          : 실시간키워드.length > 20
+            ? '검색어는 20자 이하여야 합니다.'
+            : ''}
+      </Box>
     </Container>
   );
 }

--- a/src/pages/coffeechats/coffeechat-list/FiltersAndButton.jsx
+++ b/src/pages/coffeechats/coffeechat-list/FiltersAndButton.jsx
@@ -28,7 +28,7 @@ function FiltersAndButton({ sortData, kindOfJd, onChange }) {
     navigate('/coffeechat-open');
   };
   return (
-    <Box display="flex" justifyContent="space-between" alignItems="center" mb={0.5}>
+    <Box display="flex" justifyContent="space-between" alignItems="center" mt={1.5} mb={0.5}>
       <Filters sortData={sortData} onChange={onChange} kindOfJd={kindOfJd} />
       <Button
         variant="contained"

--- a/src/pages/jd-all/components/JDSearchBar/FiltersAndButton/index.jsx
+++ b/src/pages/jd-all/components/JDSearchBar/FiltersAndButton/index.jsx
@@ -3,7 +3,7 @@ import { Filters } from './Filters';
 
 function FiltersAndButton({ sortData, kindOfJd, onChange }) {
   return (
-    <Box display="flex" justifyContent="space-between" alignItems="center" mb={0.5}>
+    <Box display="flex" justifyContent="space-between" alignItems="center" mt={1.5} mb={0.5}>
       <Filters sortData={sortData} onChange={onChange} kindOfJd={kindOfJd} />
     </Box>
   );

--- a/src/pages/mainpage/components/company-section/CompanyTitle.jsx
+++ b/src/pages/mainpage/components/company-section/CompanyTitle.jsx
@@ -2,9 +2,15 @@ import { Typography } from '@mui/material';
 import { MainStyles } from 'pages/PageStyles';
 import { titleStyle } from 'pages/mainpage/style';
 
-const CompanyTitle = ({ keyword }) => (
-  <Typography sx={MainStyles.TypoGraphy}>
-    <Typography sx={titleStyle}>{keyword}</Typography>에 관심있는 회사는 여기에요!
-  </Typography>
-);
+const CompanyTitle = ({ keyword }) => {
+  if (keyword.length > 10) {
+    keyword = `${keyword.substring(0, 15)}...`;
+  }
+
+  return (
+    <Typography sx={MainStyles.TypoGraphy}>
+      <Typography sx={titleStyle}>{keyword}</Typography>에 관심있는 회사는 여기에요!
+    </Typography>
+  );
+};
 export default CompanyTitle;

--- a/src/pages/mainpage/components/tab/StickyTabSection.jsx
+++ b/src/pages/mainpage/components/tab/StickyTabSection.jsx
@@ -105,7 +105,7 @@ function StickyTabSection({ selectedChip, setSelectedChip }) {
         <TabContext value={value}>
           <TabList
             onChange={handleTabChange}
-            sx={{ pt: 2 }}
+            sx={{ mt: 2 }}
             TabIndicatorProps={{ style: MainStyles.TabIndicator }}>
             <Tab label="요즘 뜨는 키워드" value="1" sx={MainStyles.Tab} />
             {isLoginUser ? <Tab label="내 맞춤 키워드" value="2" sx={MainStyles.Tab} /> : ''}

--- a/src/pages/mainpage/components/video-section/index.jsx
+++ b/src/pages/mainpage/components/video-section/index.jsx
@@ -16,9 +16,15 @@ function VideoSection({ loading, selectedChip, data }) {
       clearTimeout(timer);
     };
   }, []);
+
+  let keyword = selectedChip.keyword;
+  if (selectedChip.keyword.length > 10) {
+    keyword = `${selectedChip.keyword.substring(0, 15)}...`;
+  }
+
   return (
     <Box sx={{ mt: 4 }}>
-      <VideoTitle keyword={selectedChip.keyword} />
+      <VideoTitle keyword={keyword} />
       <Box display="flex">
         <Box sx={videoContainer}>
           {data.length > 0 ? (


### PR DESCRIPTION
## #️⃣연관된 이슈

close #338 

## 📝작업 내용

### 1. Header 클릭영역 only로고만 되도록 수정 및 메인 placeholder 수정

### ++ 검색 후 상단 로고를 클릭하면 메인에 검색어가 남아있던 이슈를 같이 해결했습니다.

![38](https://github.com/Kernel360/f1-JDON-Frontend/assets/122848687/c39e2353-9b99-4767-9ee4-d1c9390d2a3e)

<br/><br/>

### 2. 각 페이지별 유효성 검사 기능 추가 ( + `초기화 버튼` 및 `오류문구` )
![40](https://github.com/Kernel360/f1-JDON-Frontend/assets/122848687/9ee01c91-02a0-4906-95d5-7b9069a5513d)



## 💬리뷰 요구사항(선택)
