### PR TITLE
🚑️ Hotfix: search api 무한호출 수정 & 커피챗 skeleton ui 지연시간 발생

### DIFF
--- a/src/components/coffeechats/list-coffeechats/queryHooks/useFetchCoffeeData.jsx
+++ b/src/components/coffeechats/list-coffeechats/queryHooks/useFetchCoffeeData.jsx
@@ -1,4 +1,5 @@
 import { getCoffeeChat } from 'api/api';
+import { delay } from 'constants/delay';
 import { useQuery } from 'react-query';
 
 const useFetchCoffeeData = (currentPage, sortData, 검색어) => {
@@ -10,6 +11,7 @@ const useFetchCoffeeData = (currentPage, sortData, 검색어) => {
       sortData.jobCategory,
       검색어,
     );
+    await delay(300);
     return response.data.data;
   };
 

--- a/src/constants/delay.js
+++ b/src/constants/delay.js
@@ -1,0 +1,4 @@
+export const delay = (time) =>
+  new Promise((resolve) => {
+    setTimeout(() => resolve('delay종료'), time);
+  });

--- a/src/pages/mainpage/apiFunction.js
+++ b/src/pages/mainpage/apiFunction.js
@@ -20,6 +20,5 @@ export const fetchLectureData = async (keyword) => {
     return datas;
   } catch (error) {
     console.error('키워드별 데이터 가져오기 오류:', error);
-    return { lectureList: [], jdList: [] };
   }
 };


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #344 

## 📝작업 내용

> 

환경변수를 올바르게 설정하지 않은 경우에 search api 무한호출이 발생하는 현상을 고쳐놓았습니다
이제 무한호출은 되지 않은 채로 api 에러가 발생합니다

+ 커피챗 skeleton ui 지연시간을 0.3초 일부로 발생시키도록 수정하였습니다

## 💬리뷰 요구사항(선택)
